### PR TITLE
make it easier to copy the panic message

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 max_width = 150
 fn_args_layout = "Compressed"
 fn_call_width = 150
-fn_single_line = true
+# fn_single_line = true
 struct_lit_width = 60

--- a/src/main.rs
+++ b/src/main.rs
@@ -910,8 +910,13 @@ fn main() {
                 let (needs_repaint, shapes) = egui.run(&display, |ctx| {
                     egui::CentralPanel::default().show(ctx, |ui| {
                         egui::ScrollArea::vertical().auto_shrink([false, false]).show(ui, |ui| {
-                            ui.heading(RichText::new(format!("Error! Please report this!\n\n{}", error_string)).color(Color32::RED));
-                            ui.add_sized(ui.available_size(), TextEdit::multiline(&mut &*format!("{:?}", backtrace)));
+                            ui.horizontal(|ui| {
+                                ui.heading(RichText::new("Error! Please report this!").color(Color32::RED));
+                                if ui.button("Copy").clicked() {
+                                    ui.output().copied_text = format!("{}\n\n{:?}", error_string, backtrace);
+                                }
+                            });
+                            ui.add_sized(ui.available_size(), TextEdit::multiline(&mut &*format!("{}\n\n{:?}", error_string, backtrace)));
                         });
                     });
                 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,7 +403,9 @@ static LAST_PANIC: OnceCell<(String, Backtrace)> = OnceCell::new();
 
 fn main() {
     // set up a panic handler to grab the backtrace
-    std::panic::set_hook(Box::new(|panic_info| {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        default_hook(panic_info);
         LAST_PANIC.get_or_init(|| {
             let backtrace = backtrace::Backtrace::new();
             let msg = format!("{},  {}", panic_info.payload().downcast_ref::<String>().unwrap(), panic_info.location().unwrap());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -691,7 +691,7 @@ pub(crate) struct UiState {
 
 pub(crate) struct PofToolsGui {
     pub model: Box<Model>,
-    pub loading_thread: Option<Receiver<Option<Box<Model>>>>,
+    pub loading_thread: Option<Receiver<Result<Option<Box<Model>>, String>>>,
     pub glow_point_sim_start: std::time::Instant,
 
     pub ui_state: UiState,


### PR DESCRIPTION
This adds a "Copy" button and also moves the first line of the error
from the heading (which is not selectable) to the text box.
It is not in BIG RED TEXT like before but it is still visually grouped
with the header so it seems fine to me.

The rustfmt.toml change was necessary for me to get the same formatting behavior as the existing code.