### PR TITLE
remove OnceCell

### DIFF
--- a/pof/rustfmt.toml
+++ b/pof/rustfmt.toml
@@ -1,5 +1,5 @@
 max_width = 150
 fn_args_layout = "Compressed"
 fn_call_width = 150
-fn_single_line = true
+# fn_single_line = true
 struct_lit_width = 60

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,4 +1,4 @@
-use once_cell::sync::OnceCell;
+use once_cell::sync::Lazy;
 
 use crate::Vertex;
 
@@ -6,19 +6,15 @@ use crate::Vertex;
 // yes, there really is no better way to make just a plain sphere in opengl, can you believe that?
 // if you know a way let me know!!
 
-#[allow(non_snake_case)]
-pub(crate) fn CIRCLE_VERTS() -> &'static [Vertex; 128] {
-    static CIRCLE_VERTS: OnceCell<[Vertex; 128]> = OnceCell::new();
-    CIRCLE_VERTS.get_or_init(|| {
-        let mut verts = [Vertex { position: (0.0, 0.0, 0.0) }; 128];
-        let len = verts.len();
-        for (i, vert) in verts.iter_mut().enumerate() {
-            vert.position.0 = ((i as f32 / len as f32) * std::f32::consts::TAU).sin();
-            vert.position.1 = ((i as f32 / len as f32) * std::f32::consts::TAU).cos();
-        }
-        verts
-    })
-}
+pub(crate) static CIRCLE_VERTS: Lazy<[Vertex; 128]> = Lazy::new(|| {
+    let mut verts = [Vertex { position: (0.0, 0.0, 0.0) }; 128];
+    let len = verts.len();
+    for (i, vert) in verts.iter_mut().enumerate() {
+        vert.position.0 = ((i as f32 / len as f32) * std::f32::consts::TAU).sin();
+        vert.position.1 = ((i as f32 / len as f32) * std::f32::consts::TAU).cos();
+    }
+    verts
+});
 
 pub(crate) const CIRCLE_INDICES: [u16; 128] = {
     let mut i = 0;


### PR DESCRIPTION
I actually read the documentation, and found the `once_cell::sync::Lazy` type which is a better match for lazy statics than using `OnceCell` directly. Also the `OnceCell` used in the panic handler can be replaced by a channel to avoid needing a global.

Also fixes a few unused item warnings and the rustfmt.toml file in `pof/`.