### PR TITLE
add old version handling, fewer IO unwraps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,9 +571,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "dae-parser"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33a21e9356c71f3fbbe47dc772dc1ba6484d0eab118d4aafe54e76ee9773c70"
+checksum = "6b6790ec544e179e18266a2862bf4bcdd462283c1e58f2885f1961ffa1b1245d"
 dependencies = [
  "chrono",
  "minidom",

--- a/pof/Cargo.toml
+++ b/pof/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 byteorder = "1.2"
 #dae-parser = {path = "dae-parser-0.8.3", features = ["nalgebra"]}
-dae-parser = {version = "0.8.5", features = ["nalgebra"]}
+dae-parser = {version = "0.8", features = ["nalgebra"]}
 walkdir = "2"
 nalgebra = "0.30.1"
 nalgebra-glm = "0.16"

--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -715,7 +715,7 @@ fn parse_bsp_data(mut buf: &[u8]) -> io::Result<BspData> {
 }
 
 fn parse_shield_node(buf: &[u8], version: Version) -> io::Result<Box<ShieldNode>> {
-    let (chunk_type, mut chunk, _) = parse_chunk_header(buf, version <= Version::V21_17)?;
+    let (chunk_type, mut chunk, _) = parse_chunk_header(buf, version < Version::V21_18)?;
     Ok(Box::new(match chunk_type {
         ShieldNode::SPLIT => ShieldNode::Split {
             bbox: read_bbox(&mut chunk)?,

--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -261,7 +261,9 @@ impl<R: Read + Seek> Parser<R> {
                     //println!("{:#?}", eye_points);
                 }
                 b"GPNT" | b"MPNT" => {
-                    let list = self.read_list(|this| {
+                    let target = if id == b"GPNT" { &mut primary_weps } else { &mut secondary_weps };
+                    assert!(target.is_none());
+                    *target = Some(self.read_list(|this| {
                         this.read_list(|this| {
                             Ok(WeaponHardpoint {
                                 position: this.read_vec3d()?,
@@ -274,14 +276,8 @@ impl<R: Read + Seek> Parser<R> {
                                 },
                             })
                         })
-                    })?;
-                    if id == b"GPNT" {
-                        primary_weps = Some(list);
-                        //println!("{:#?}", primary_weps);
-                    } else {
-                        secondary_weps = Some(list);
-                        //println!("{:#?}", secondary_weps);
-                    }
+                    })?);
+                    //println!("{:#?}", target);
                 }
                 b"TGUN" | b"TMIS" => {
                     turrets.extend(self.read_list(|this| {

--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -211,7 +211,7 @@ impl Display for Vec3d {
 }
 impl Vec3d {
     pub const ZERO: Vec3d = Vec3d { x: 0.0, y: 0.0, z: 0.0 };
-    pub fn new(x: f32, y: f32, z: f32) -> Self {
+    pub const fn new(x: f32, y: f32, z: f32) -> Self {
         Vec3d { x, y, z }
     }
     pub fn to_tuple(self) -> (f32, f32, f32) {
@@ -358,6 +358,13 @@ impl From<glm::Mat3x3> for Mat3d {
         }
     }
 }
+impl MulAssign<f32> for Mat3d {
+    fn mul_assign(&mut self, rhs: f32) {
+        self.rvec *= rhs;
+        self.uvec *= rhs;
+        self.fvec *= rhs;
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct NormalVec3(pub Vec3d);
@@ -392,6 +399,12 @@ impl FromStr for NormalVec3 {
 }
 
 impl Mat3d {
+    pub const IDENTITY: Mat3d = Mat3d {
+        rvec: Vec3d::new(1., 0., 0.),
+        uvec: Vec3d::new(0., 1., 0.),
+        fvec: Vec3d::new(0., 0., 1.),
+    };
+
     pub fn add_point_mass_moi(&mut self, pos: Vec3d) {
         self.rvec.x += pos.y * pos.y + pos.z * pos.z;
         self.rvec.y -= pos.x * pos.y;
@@ -1375,7 +1388,12 @@ impl GlowPointBank {
 mk_enumeration! {
     #[derive(PartialOrd, Ord, PartialEq, Eq, Debug, Clone, Copy)]
     pub enum Version(i32) {
-        V21_16 = 2116, // (retail)
+        V19_03 = 1903, // mass / MOI introduced
+        V20_04 = 2004, // glow point radius introduced after this
+        V20_07 = 2007, // muzzle flash introduced
+        V20_09 = 2009, // area mass conversion
+        V20_14 = 2014, // (retail freespace 1) cross sections introduced
+        V21_16 = 2116, // (retail freespace 2)
         V21_17 = 2117, // (retail) thruster properties
         V21_18 = 2118, // weapon offset
         V22_00 = 2200, // aligned and SLC2
@@ -1390,6 +1408,11 @@ impl Default for Version {
 impl Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Version::V19_03 => write!(f, "19.03"),
+            Version::V20_04 => write!(f, "20.04"),
+            Version::V20_07 => write!(f, "20.07"),
+            Version::V20_09 => write!(f, "20.09"),
+            Version::V20_14 => write!(f, "20.14"),
             Version::V21_16 => write!(f, "21.16"),
             Version::V21_17 => write!(f, "21.17"),
             Version::V21_18 => write!(f, "21.18"),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -573,29 +573,17 @@ impl PofToolsGui {
                 ui.separator();
 
                 ui.menu_button(RichText::new(format!("Version: {}", self.model.version)).text_style(TextStyle::Button), |ui| {
-                    let mut response = ui
-                        .radio_value(&mut self.model.version, Version::V21_16, "21.16")
-                        .on_hover_text("Retail - PCS2 Compatible");
-                    response = response.union(
-                        ui.radio_value(&mut self.model.version, Version::V21_17, "21.17")
-                            .on_hover_text("Retail - PCS2 Compatible - Thruster properties added"),
-                    );
-                    response = response.union(
-                        ui.radio_value(&mut self.model.version, Version::V21_18, "21.18")
-                            .on_hover_text("External weapon angle offset added"),
-                    );
-                    response = response.union(
-                        ui.radio_value(&mut self.model.version, Version::V22_00, "22.00")
-                            .on_hover_text("SLC2 replaces SLDC (no weapon offset compatibility)"),
-                    );
-                    response = response.union(
-                        ui.radio_value(&mut self.model.version, Version::V22_01, "22.01")
-                            .on_hover_text("External weapon angle offset compatible"),
-                    );
+                    let mut changed = false;
+                    Version::for_each(|version| {
+                        changed |= ui
+                            .radio_value(&mut self.model.version, version, version.to_str())
+                            .on_hover_text(version.documentation())
+                            .changed();
+                    });
 
                     // we only need to recheck verson-specific warnings, but since those are parameterized, there's no easy way to say
                     // 'those specific warnings but for all their parameters' so just do them all i guess
-                    if response.changed() {
+                    if changed {
                         PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All);
                     }
                 });

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -575,10 +575,12 @@ impl PofToolsGui {
                 ui.menu_button(RichText::new(format!("Version: {}", self.model.version)).text_style(TextStyle::Button), |ui| {
                     let mut changed = false;
                     Version::for_each(|version| {
-                        changed |= ui
-                            .radio_value(&mut self.model.version, version, version.to_str())
-                            .on_hover_text(version.documentation())
-                            .changed();
+                        if version >= Version::V21_16 {
+                            changed |= ui
+                                .radio_value(&mut self.model.version, version, version.to_str())
+                                .on_hover_text(version.documentation())
+                                .changed();
+                        }
                     });
 
                     // we only need to recheck verson-specific warnings, but since those are parameterized, there's no easy way to say


### PR DESCRIPTION
Adds support for lots of ancient versions which appear in the FSO parser and/or POF documentation. (I think it would be fine to drop support for really old versions with no extant POF files, but only if FSO also drops support.) Also replaces `.unwrap()` with `?` for all IO errors in parsing.

Also there are a few version checks that did not match the [wiki description](https://wiki.hard-light.net/index.php/POF_data_structure), this should be fixed.