### PR TITLE
Introduce new properties handling

### DIFF
--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -1721,7 +1721,7 @@ pub fn properties_update_field(properties: &mut String, field: &str, val: &str) 
         if properties.is_empty() {
             *properties = format!("{}={}", field, val);
         } else {
-            *properties = format!("{}\n{}={}", properties, field, val);
+            *properties = format!("{}\n{}{}", properties, field, val);
         }
     }
 }

--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -1711,17 +1711,15 @@ fn properties_find_field(properties: &String, field: &str) -> Option<(usize, usi
 }
 
 pub fn properties_update_field(properties: &mut String, field: &str, val: &str) {
-    if let Some((start_idx, end_idx)) = properties_find_field(properties, field) {
-        if val == "" {
-            properties_delete_field(properties, field);
-        } else {
-            *properties = format!("{}{}{}", &properties[..start_idx], val, &properties[end_idx..]);
-        }
+    if val == "" {
+        properties_delete_field(properties, field);
     } else {
         if properties.is_empty() {
             *properties = format!("{}={}", field, val);
+        } else if let Some((start_idx, end_idx)) = properties_find_field(properties, field) {
+            *properties = format!("{}{}{}", &properties[..start_idx], val, &properties[end_idx..]);
         } else {
-            *properties = format!("{}\n{}{}", properties, field, val);
+            *properties = format!("{}\n{}={}", properties, field, val);
         }
     }
 }
@@ -1732,4 +1730,14 @@ pub fn properties_get_field<'a>(properties: &'a String, field: &str) -> Option<&
     } else {
         None
     }
+}
+
+pub fn properties_set_flag(properties: &mut String, flag: &str) {
+    if properties_find_field(properties, flag).is_none() {
+        *properties = format!("{}\n{}", properties, flag);
+    }
+}
+
+pub fn properties_remove_flag(properties: &mut String, flag: &str) {
+    properties_delete_field(properties, flag);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -596,6 +596,14 @@ fn main() {
     pt_gui.camera_offset = Vec3d::ZERO;
     pt_gui.camera_scale = model.header.max_radius * 2.0;
 
+    // let mut str1 = String::from("asd=dsa\n123 = 321\nddd =01\n");
+    // pof::properties_update_field(&mut str1, "asd", "");
+    // println!("{:?}\n", str1);
+    // pof::properties_update_field(&mut str1, "ddd", "");
+    // println!("{:?}\n", str1);
+    // pof::properties_update_field(&mut str1, "123", "");
+    // println!("{:?}\n", str1);
+
     let mut errored = None;
 
     event_loop.run(move |event, _, control_flow| {
@@ -1326,7 +1334,12 @@ impl PofToolsGui {
                     &COLORS,
                     display,
                     model.docking_bays.iter().enumerate().flat_map(|(bay_idx, docking_bay)| {
-                        let position = docking_bay.position;
+                        let mut position = docking_bay.position;
+                        if let Some(parent_name) = pof::properties_get_field(&docking_bay.properties, "$parent_submodel") {
+                            if let Some(id) = model.get_obj_id_by_name(parent_name) {
+                                position += model.get_total_subobj_offset(id);
+                            }
+                        }
                         let radius = self.model.header.max_radius.powf(0.4) / 4.0;
                         let fvec = docking_bay.fvec.0 * radius * 3.0;
                         let uvec = docking_bay.uvec.0 * radius * 3.0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -596,14 +596,6 @@ fn main() {
     pt_gui.camera_offset = Vec3d::ZERO;
     pt_gui.camera_scale = model.header.max_radius * 2.0;
 
-    // let mut str1 = String::from("asd=dsa\n123 = 321\nddd =01\n");
-    // pof::properties_update_field(&mut str1, "asd", "");
-    // println!("{:?}\n", str1);
-    // pof::properties_update_field(&mut str1, "ddd", "");
-    // println!("{:?}\n", str1);
-    // pof::properties_update_field(&mut str1, "123", "");
-    // println!("{:?}\n", str1);
-
     let mut errored = None;
 
     event_loop.run(move |event, _, control_flow| {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -925,8 +925,7 @@ impl PofToolsGui {
                                     &format!(
                                         "Bank {}{}",
                                         i + 1,
-                                        self.model.glow_banks[i]
-                                            .get_glow_texture()
+                                        pof::properties_get_field(&self.model.glow_banks[i].properties, "$glow_texture")
                                             .map_or(String::new(), |tex| format!(" ({})", tex))
                                     ),
                                     TreeSelection::Glows(GlowSelection::Bank(i)),

--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -1285,7 +1285,7 @@ impl PofToolsGui {
                             UiState::set_widget_color(ui, Color32::YELLOW);
                         }
                         if ui.text_edit_singleline(engine_subsys_string).changed() {
-                            pof::properties_update_field(&mut self.model.thruster_banks[bank].properties, "$engine_subsystem", engine_subsys_string);
+                            pof::properties_update_field(&mut self.model.thruster_banks[bank].properties, "$engine_subsystem=", engine_subsys_string);
                         }
                         UiState::reset_widget_color(ui);
                     } else {
@@ -1470,7 +1470,7 @@ impl PofToolsGui {
                     ui.label("Name:");
                     if let Some(bay) = bay_num {
                         if ui.text_edit_singleline(name_string).changed() {
-                            pof::properties_update_field(&mut self.model.docking_bays[bay].properties, "$name", name_string);
+                            pof::properties_update_field(&mut self.model.docking_bays[bay].properties, "$name=", name_string);
                         }
                     } else {
                         ui.add_enabled(false, egui::TextEdit::singleline(&mut blank_string));
@@ -1494,7 +1494,7 @@ impl PofToolsGui {
                 if let Some(new_subobj) = UiState::subobject_combo_box(ui, &subobj_names_list, &mut parent_id, bay_num, "Parent Object", None) {
                     pof::properties_update_field(
                         &mut self.model.docking_bays[bay_num.unwrap()].properties,
-                        "$parent_submodel",
+                        "$parent_submodel=",
                         &subobj_names_list[new_subobj],
                     );
                     self.ui_state.viewport_3d_dirty = true;
@@ -1631,7 +1631,7 @@ impl PofToolsGui {
                 ui.label("Glow Texture:");
                 if let Some(bank) = bank_num {
                     if ui.add(egui::TextEdit::singleline(glow_texture_string).desired_rows(1)).changed() {
-                        pof::properties_update_field(&mut self.model.glow_banks[bank].properties, "$glow_texture", glow_texture_string);
+                        pof::properties_update_field(&mut self.model.glow_banks[bank].properties, "$glow_texture=", glow_texture_string);
                     }
                 } else {
                     ui.add_enabled(false, egui::TextEdit::singleline(&mut blank_string).desired_rows(1));
@@ -1788,7 +1788,7 @@ impl PofToolsGui {
                             changed |= ui.selectable_value(&mut idx, 2, types_display[2]).changed();
                         });
                         if changed {
-                            pof::properties_update_field(&mut self.model.special_points[point].properties, "$special", types[idx]);
+                            pof::properties_update_field(&mut self.model.special_points[point].properties, "$special=", types[idx]);
                         }
                     } else {
                         egui::ComboBox::from_label("Type").show_ui(ui, |ui| {

--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -1285,7 +1285,7 @@ impl PofToolsGui {
                             UiState::set_widget_color(ui, Color32::YELLOW);
                         }
                         if ui.text_edit_singleline(engine_subsys_string).changed() {
-                            pof::properties_update_field(&mut self.model.thruster_banks[bank].properties, "$engine_subsystem=", engine_subsys_string);
+                            pof::properties_update_field(&mut self.model.thruster_banks[bank].properties, "$engine_subsystem", engine_subsys_string);
                         }
                         UiState::reset_widget_color(ui);
                     } else {
@@ -1470,7 +1470,7 @@ impl PofToolsGui {
                     ui.label("Name:");
                     if let Some(bay) = bay_num {
                         if ui.text_edit_singleline(name_string).changed() {
-                            pof::properties_update_field(&mut self.model.docking_bays[bay].properties, "$name=", name_string);
+                            pof::properties_update_field(&mut self.model.docking_bays[bay].properties, "$name", name_string);
                         }
                     } else {
                         ui.add_enabled(false, egui::TextEdit::singleline(&mut blank_string));
@@ -1494,7 +1494,7 @@ impl PofToolsGui {
                 if let Some(new_subobj) = UiState::subobject_combo_box(ui, &subobj_names_list, &mut parent_id, bay_num, "Parent Object", None) {
                     pof::properties_update_field(
                         &mut self.model.docking_bays[bay_num.unwrap()].properties,
-                        "$parent_submodel=",
+                        "$parent_submodel",
                         &subobj_names_list[new_subobj],
                     );
                     self.ui_state.viewport_3d_dirty = true;
@@ -1631,7 +1631,7 @@ impl PofToolsGui {
                 ui.label("Glow Texture:");
                 if let Some(bank) = bank_num {
                     if ui.add(egui::TextEdit::singleline(glow_texture_string).desired_rows(1)).changed() {
-                        pof::properties_update_field(&mut self.model.glow_banks[bank].properties, "$glow_texture=", glow_texture_string);
+                        pof::properties_update_field(&mut self.model.glow_banks[bank].properties, "$glow_texture", glow_texture_string);
                     }
                 } else {
                     ui.add_enabled(false, egui::TextEdit::singleline(&mut blank_string).desired_rows(1));
@@ -1788,7 +1788,7 @@ impl PofToolsGui {
                             changed |= ui.selectable_value(&mut idx, 2, types_display[2]).changed();
                         });
                         if changed {
-                            pof::properties_update_field(&mut self.model.special_points[point].properties, "$special=", types[idx]);
+                            pof::properties_update_field(&mut self.model.special_points[point].properties, "$special", types[idx]);
                         }
                     } else {
                         egui::ComboBox::from_label("Type").show_ui(ui, |ui| {


### PR DESCRIPTION
Turn all the fields in properties into explicit fields and 'hide' the raw text manipulation of properties... for all but subobjects, because they're by far the most complicated.