### PR TITLE
normalize turret/gunpoint/eyepoint normals

### DIFF
--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -528,24 +528,13 @@ mk_struct! {
         pub kind: BspLightKind,
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Default, Debug, Clone)]
     pub struct EyePoint {
         pub attached_subobj: ObjectId,
         pub offset: Vec3d,
-        pub normal: Vec3d,
+        pub normal: NormalVec3,
     }
-}
-impl Default for EyePoint {
-    fn default() -> Self {
-        Self {
-            attached_subobj: ObjectId(0),
-            offset: Default::default(),
-            normal: Vec3d::new(0.0, 0.0, 1.0),
-        }
-    }
-}
 
-mk_struct! {
     #[derive(Debug, Clone, Default)]
     pub struct PathPoint {
         pub position: Vec3d,
@@ -684,10 +673,10 @@ impl Default for SpecialPoint {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct WeaponHardpoint {
     pub position: Vec3d,
-    pub normal: Vec3d,
+    pub normal: NormalVec3,
     pub offset: f32,
 }
 impl Serialize for WeaponHardpoint {
@@ -699,15 +688,6 @@ impl Serialize for WeaponHardpoint {
             self.offset.write_to(w)?;
         }
         Ok(())
-    }
-}
-impl Default for WeaponHardpoint {
-    fn default() -> Self {
-        Self {
-            position: Default::default(),
-            normal: Vec3d { x: 0.0, y: 0.0, z: 1.0 },
-            offset: Default::default(),
-        }
     }
 }
 
@@ -1328,7 +1308,7 @@ mk_struct! {
     pub struct Turret {
         pub base_obj: ObjectId,
         pub gun_obj: ObjectId,
-        pub normal: Vec3d,
+        pub normal: NormalVec3,
         pub fire_points: Vec<Vec3d>,
     }
 }
@@ -1451,6 +1431,8 @@ mk_versions! {
     V20_09(2009, "20.09"),
     /// Retail FS1 - Cross sections introduced
     V20_14(2014, "20.14"),
+    /// FS1 POFs produced by COB2FS v0.05
+    V20_16(2016, "20.16"),
     /// Retail FS2 - PCS2 Compatible
     V21_16(2116, "21.16"),
     /// Retail FS2 - PCS2 Compatible - Thruster properties added

--- a/pof/src/write.rs
+++ b/pof/src/write.rs
@@ -102,6 +102,11 @@ impl Serialize for i32 {
         w.write_i32::<LE>(*self)
     }
 }
+impl Serialize for crate::NormalVec3 {
+    fn write_to(&self, w: &mut impl Write) -> io::Result<()> {
+        self.0.write_to(w)
+    }
+}
 
 fn align_buf(buf: &mut Vec<u8>) -> io::Result<()> {
     let padding_length = buf.len().wrapping_neg() % 4;
@@ -519,7 +524,7 @@ fn make_weapons_node(weapons: &[Vec<WeaponHardpoint>], kind: &str) -> Node {
             let mut point_node = Node::new(format!("#w{}b{}-point{}", &kind[0..1], i, j), Some(format!("#w{}b{}-point{}", &kind[0..1], i, j)));
             let pos = point.position;
             point_node.push_transform(Translate::new([pos.x, pos.z, pos.y])); // itentional swizzle
-            point_node.push_transform(vec_to_rotation(&point.normal));
+            point_node.push_transform(vec_to_rotation(&point.normal.0));
 
             if point.offset != 0.0 {
                 point_node.children.push(Node::new(
@@ -650,7 +655,7 @@ fn make_eyes_node(eye_points: &[EyePoint]) -> Node {
 
         let pos = point.offset;
         point_node.push_transform(Translate::new([pos.x, pos.z, pos.y])); // itentional swizzle
-        point_node.push_transform(vec_to_rotation(&point.normal));
+        point_node.push_transform(vec_to_rotation(&point.normal.0));
 
         point_node
             .children
@@ -901,7 +906,7 @@ fn make_subobj_node(
 
                 let mut gunpoint_node = Node::new(name.clone(), Some(name));
                 gunpoint_node.push_transform(Translate::new([point.x, point.z, point.y]));
-                gunpoint_node.push_transform(vec_to_rotation(&turret.normal));
+                gunpoint_node.push_transform(vec_to_rotation(&turret.normal.0));
                 node.children.push(gunpoint_node);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -742,7 +742,7 @@ fn main() {
                                 .filter(|_| pt_gui.display_mode == DisplayMode::Textured)
                                 // if we're displaying textures...
                                 .and_then(|tex_id| pt_gui.buffer_textures.get(&tex_id))
-                            // and we have a texture loaded, then display
+                            //     and we have a texture loaded, then display
                             {
                                 // draw textured
                                 let uniforms = glium::uniform! {
@@ -1309,7 +1309,7 @@ impl PofToolsGui {
                         weapon_bank.iter().enumerate().map(move |(point_idx, weapon_point)| {
                             let position = weapon_point.position;
                             let radius = model.header.max_radius * 0.03;
-                            let normal = weapon_point.normal * radius * 2.0;
+                            let normal = weapon_point.normal.0 * radius * 2.0;
                             let selection = if selected_bank == Some(bank_idx) {
                                 if selected_point == Some(point_idx) {
                                     SELECTED_POINT
@@ -1433,7 +1433,7 @@ impl PofToolsGui {
                         let offset = self.model.get_total_subobj_offset(turret.gun_obj);
                         turret.fire_points.iter().enumerate().map(move |(point_idx, fire_point)| {
                             let position = *fire_point + offset;
-                            let normal = turret.normal * size * 2.0;
+                            let normal = turret.normal.0 * size * 2.0;
                             let radius = size;
                             let selection = if selected_turret == Some(turret_idx) {
                                 if selected_point == Some(point_idx) {
@@ -1508,7 +1508,7 @@ impl PofToolsGui {
                     display,
                     model.eye_points.iter().enumerate().map(|(eye_idx, eye_point)| {
                         let position = eye_point.offset;
-                        let normal = eye_point.normal * size * 2.0;
+                        let normal = eye_point.normal.0 * size * 2.0;
                         let radius = size;
                         let selection = if selected_eye == Some(eye_idx) { SELECTED_POINT } else { UNSELECTED };
                         (position, normal, radius, selection)

--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -444,14 +444,14 @@ impl UiState {
                 WeaponSelection::PriBankPoint(bank_idx, point_idx) => {
                     self.properties_panel = PropertiesPanel::Weapon {
                         position_string: format!("{}", model.primary_weps[bank_idx][point_idx].position),
-                        normal_string: format!("{}", model.primary_weps[bank_idx][point_idx].normal),
+                        normal_string: format!("{}", model.primary_weps[bank_idx][point_idx].normal.0),
                         offset_string: format!("{}", model.primary_weps[bank_idx][point_idx].offset),
                     }
                 }
                 WeaponSelection::SecBankPoint(bank_idx, point_idx) => {
                     self.properties_panel = PropertiesPanel::Weapon {
                         position_string: format!("{}", model.secondary_weps[bank_idx][point_idx].position),
-                        normal_string: format!("{}", model.secondary_weps[bank_idx][point_idx].normal),
+                        normal_string: format!("{}", model.secondary_weps[bank_idx][point_idx].normal.0),
                         offset_string: format!("{}", model.secondary_weps[bank_idx][point_idx].offset),
                     }
                 }
@@ -514,14 +514,14 @@ impl UiState {
             TreeSelection::Turrets(turret_selection) => match turret_selection {
                 TurretSelection::TurretPoint(turret, point) => {
                     self.properties_panel = PropertiesPanel::Turret {
-                        normal_string: format!("{}", model.turrets[turret].normal),
+                        normal_string: format!("{}", model.turrets[turret].normal.0),
                         base_idx: model.turrets[turret].base_obj.0 as usize,
                         position_string: format!("{}", model.turrets[turret].fire_points[point]),
                     }
                 }
                 TurretSelection::Turret(turret) => {
                     self.properties_panel = PropertiesPanel::Turret {
-                        normal_string: format!("{}", model.turrets[turret].normal),
+                        normal_string: format!("{}", model.turrets[turret].normal.0),
                         base_idx: model.turrets[turret].base_obj.0 as usize,
                         position_string: Default::default(),
                     }
@@ -560,7 +560,7 @@ impl UiState {
                 EyeSelection::EyePoint(idx) => {
                     self.properties_panel = PropertiesPanel::EyePoint {
                         position_string: format!("{}", model.eye_points[idx].offset),
-                        normal_string: format!("{}", model.eye_points[idx].normal),
+                        normal_string: format!("{}", model.eye_points[idx].normal.0),
                         attached_subobj_idx: model.eye_points[idx].attached_subobj.0 as usize,
                     }
                 }


### PR DESCRIPTION
some minor tweaks discovered from reading an ancient POF parser. Relevantly, turrets, gunpoints and eyepoint normals must be normalized (or at least, nonzero). Since we already have eager normalization in dockpoints it seems consistent to do the same with these normals. (Glowpoint normals are *not* similarly asserted to be nonzero, although I believe the reason is because they are `Option<NormalVec3>`: they are either normalized or zero.)