### PR TITLE
Make shaders more permissive

### DIFF
--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -713,7 +713,7 @@ fn parse_bsp_data(mut buf: &[u8]) -> io::Result<BspData> {
 }
 
 fn parse_shield_node(buf: &[u8], version: Version) -> io::Result<Box<ShieldNode>> {
-    let (chunk_type, mut chunk, _) = parse_chunk_header(buf, version < Version::V21_18)?;
+    let (chunk_type, mut chunk, _) = parse_chunk_header(buf, version < Version::V22_00)?;
     Ok(Box::new(match chunk_type {
         ShieldNode::SPLIT => ShieldNode::Split {
             bbox: read_bbox(&mut chunk)?,

--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -660,7 +660,7 @@ impl Serialize for ShieldNode {
     fn write_to(&self, w: &mut impl Write) -> io::Result<()> {
         let mut buf = vec![];
 
-        crate::write::write_shield_node(&mut buf, self, get_version!() < Version::V21_18)?;
+        crate::write::write_shield_node(&mut buf, self, get_version!() < Version::V22_00)?;
 
         w.write_u32::<LE>((buf.len()) as u32)?;
         w.write_all(&buf)


### PR DESCRIPTION
Move `transpose` and `inverse` out of the shader so we can support more setups.

Also a small shield parsing fix.