### PR TITLE
remove Polygon.center and calculate it on the fly

### DIFF
--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -637,7 +637,7 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                             BspData::TMAPPOLY => {
                                 let normal = read_vec3d(&mut chunk)?;
                                 let _center = read_vec3d(&mut chunk)?;
-                                let radius = chunk.read_f32::<LE>()?;
+                                let _radius = chunk.read_f32::<LE>()?;
                                 let num_verts = chunk.read_u32::<LE>()?;
                                 let texture = Texturing::Texture(TextureId(chunk.read_u32::<LE>()?));
                                 let verts = read_list_n(num_verts as usize, &mut chunk, |chunk| {
@@ -648,12 +648,12 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                                     })
                                 })?;
 
-                                Polygon { normal, radius, verts, texture }
+                                Polygon { normal, verts, texture }
                             }
                             BspData::FLATPOLY => {
                                 let normal = read_vec3d(&mut chunk)?;
                                 let _center = read_vec3d(&mut chunk)?;
-                                let radius = chunk.read_f32::<LE>()?;
+                                let _radius = chunk.read_f32::<LE>()?;
                                 let num_verts = chunk.read_u32::<LE>()?;
                                 let texture = Texturing::Flat(Color {
                                     red: chunk.read_u8()?,
@@ -669,7 +669,7 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                                     })
                                 })?;
 
-                                Polygon { normal, radius, verts, texture }
+                                Polygon { normal, verts, texture }
                             }
                             BspData::ENDOFBRANCH => {
                                 break;
@@ -964,12 +964,9 @@ fn dae_parse_subobject_recursive(
                 norms: normals_out,
                 collision_tree: BspData::recalculate(
                     &vertices_out,
-                    polygons_out.into_iter().map(|(texture, verts)| Polygon {
-                        normal: Default::default(),
-                        radius: Default::default(),
-                        texture,
-                        verts,
-                    }),
+                    polygons_out
+                        .into_iter()
+                        .map(|(texture, verts)| Polygon { normal: Default::default(), texture, verts }),
                 ),
                 verts: vertices_out,
             },
@@ -1184,12 +1181,9 @@ pub fn parse_dae(path: std::path::PathBuf) -> Box<Model> {
                         norms: normals_out,
                         collision_tree: BspData::recalculate(
                             &vertices_out,
-                            polygons_out.into_iter().map(|(texture, verts)| Polygon {
-                                normal: Default::default(),
-                                radius: Default::default(),
-                                texture,
-                                verts,
-                            }),
+                            polygons_out
+                                .into_iter()
+                                .map(|(texture, verts)| Polygon { normal: Default::default(), texture, verts }),
                         ),
                         verts: vertices_out,
                     },

--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -603,13 +603,19 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                     let _point = read_vec3d(&mut chunk)?;
                     let _reserved = chunk.read_u32::<LE>()?; // just to advance past it
                     let offset = chunk.read_u32::<LE>()?;
-                    assert!(offset != 0);
-                    parse_bsp_node(&buf[offset as usize..], verts, version)?
+                    if offset == 0 {
+                        Box::new(BspNode::Empty)
+                    } else {
+                        parse_bsp_node(&buf[offset as usize..], verts, version)?
+                    }
                 },
                 back: {
                     let offset = chunk.read_u32::<LE>()?;
-                    assert!(offset != 0);
-                    parse_bsp_node(&buf[offset as usize..], verts, version)?
+                    if offset == 0 {
+                        Box::new(BspNode::Empty)
+                    } else {
+                        parse_bsp_node(&buf[offset as usize..], verts, version)?
+                    }
                 },
                 bbox: {
                     let _prelist = chunk.read_u32::<LE>()?; //
@@ -687,6 +693,7 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                     _ => BspData::recalculate(verts, poly_list.into_iter()),
                 }
             }
+            BspData::ENDOFBRANCH => BspNode::Empty,
             _ => {
                 unreachable!();
             }

--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -598,9 +598,9 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
         //dbg!(chunk_type);
         Ok(Box::new(match chunk_type {
             BspData::SORTNORM => BspNode::Split {
-                normal: read_vec3d(&mut chunk)?,
-                point: read_vec3d(&mut chunk)?,
                 front: {
+                    let _normal = read_vec3d(&mut chunk)?;
+                    let _point = read_vec3d(&mut chunk)?;
                     let _reserved = chunk.read_u32::<LE>()?; // just to advance past it
                     let offset = chunk.read_u32::<LE>()?;
                     assert!(offset != 0);
@@ -613,10 +613,10 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                 },
                 bbox: {
                     let _prelist = chunk.read_u32::<LE>()?; //
-                    let _postlist = chunk.read_u32::<LE>()?; // All 3 completely unused, as far as i can tell
+                    let _postlist = chunk.read_u32::<LE>()?; // All 3 completely unused, as far as I can tell
                     let _online = chunk.read_u32::<LE>()?; //
                     assert!(_prelist == 0 || buf[_prelist as usize] == 0); //
-                    assert!(_postlist == 0 || buf[_postlist as usize] == 0); // And so let's make sure thats the case, they should all lead to ENDOFBRANCH
+                    assert!(_postlist == 0 || buf[_postlist as usize] == 0); // And so let's make sure that's the case, they should all lead to ENDOFBRANCH
                     assert!(_online == 0 || buf[_online as usize] == 0); //
                     if version >= Version::V20_00 {
                         read_bbox(&mut chunk)?

--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -636,7 +636,7 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                         poly_list.push(match chunk_type {
                             BspData::TMAPPOLY => {
                                 let normal = read_vec3d(&mut chunk)?;
-                                let center = read_vec3d(&mut chunk)?;
+                                let _center = read_vec3d(&mut chunk)?;
                                 let radius = chunk.read_f32::<LE>()?;
                                 let num_verts = chunk.read_u32::<LE>()?;
                                 let texture = Texturing::Texture(TextureId(chunk.read_u32::<LE>()?));
@@ -648,11 +648,11 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                                     })
                                 })?;
 
-                                Polygon { normal, center, radius, verts, texture }
+                                Polygon { normal, radius, verts, texture }
                             }
                             BspData::FLATPOLY => {
                                 let normal = read_vec3d(&mut chunk)?;
-                                let center = read_vec3d(&mut chunk)?;
+                                let _center = read_vec3d(&mut chunk)?;
                                 let radius = chunk.read_f32::<LE>()?;
                                 let num_verts = chunk.read_u32::<LE>()?;
                                 let texture = Texturing::Flat(Color {
@@ -669,7 +669,7 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                                     })
                                 })?;
 
-                                Polygon { normal, center, radius, verts, texture }
+                                Polygon { normal, radius, verts, texture }
                             }
                             BspData::ENDOFBRANCH => {
                                 break;
@@ -717,12 +717,8 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
 
     let mut bsp_tree = *parse_bsp_node(next_chunk, version)?;
 
-    if version < Version::V20_03 {
-        // TODO: always recalculate?
-        bsp_tree.recalculate_centers(&verts);
-        if version < Version::V20_00 {
-            bsp_tree.recalculate_bboxes(&verts);
-        }
+    if version < Version::V20_00 {
+        bsp_tree.recalculate_bboxes(&verts);
     }
 
     Ok(BspData { collision_tree: bsp_tree, norms, verts })
@@ -970,7 +966,6 @@ fn dae_parse_subobject_recursive(
                     &vertices_out,
                     polygons_out.into_iter().map(|(texture, verts)| Polygon {
                         normal: Default::default(),
-                        center: Default::default(),
                         radius: Default::default(),
                         texture,
                         verts,
@@ -1191,7 +1186,6 @@ pub fn parse_dae(path: std::path::PathBuf) -> Box<Model> {
                             &vertices_out,
                             polygons_out.into_iter().map(|(texture, verts)| Polygon {
                                 normal: Default::default(),
-                                center: Default::default(),
                                 radius: Default::default(),
                                 texture,
                                 verts,

--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -590,7 +590,7 @@ fn parse_chunk_header(buf: &[u8], chunk_type_is_u8: bool) -> io::Result<(u32, &[
 }
 
 fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
-    fn parse_bsp_node(mut buf: &[u8], version: Version) -> io::Result<Box<BspNode>> {
+    fn parse_bsp_node(mut buf: &[u8], verts: &[Vec3d], version: Version) -> io::Result<Box<BspNode>> {
         // parse the first header
         let (chunk_type, mut chunk, next_chunk) = parse_chunk_header(buf, false)?;
         // the first chunk (after deffpoints) AND the chunks pointed to be SORTNORM's front and back branches should ALWAYS be either another
@@ -604,12 +604,12 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                     let _reserved = chunk.read_u32::<LE>()?; // just to advance past it
                     let offset = chunk.read_u32::<LE>()?;
                     assert!(offset != 0);
-                    parse_bsp_node(&buf[offset as usize..], version)?
+                    parse_bsp_node(&buf[offset as usize..], verts, version)?
                 },
                 back: {
                     let offset = chunk.read_u32::<LE>()?;
                     assert!(offset != 0);
-                    parse_bsp_node(&buf[offset as usize..], version)?
+                    parse_bsp_node(&buf[offset as usize..], verts, version)?
                 },
                 bbox: {
                     let _prelist = chunk.read_u32::<LE>()?; //
@@ -625,67 +625,68 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
                     }
                 },
             },
-            BspData::BOUNDBOX => BspNode::Leaf {
-                bbox: read_bbox(&mut chunk)?,
-                poly_list: {
-                    let mut poly_list = vec![];
+            BspData::BOUNDBOX => {
+                let bbox = read_bbox(&mut chunk)?;
+                let mut poly_list = vec![];
+                buf = next_chunk;
+                loop {
+                    let (chunk_type, mut chunk, next_chunk) = parse_chunk_header(buf, false)?;
+                    // keeping looping and pushing new polygons
+                    poly_list.push(match chunk_type {
+                        BspData::TMAPPOLY => {
+                            let normal = read_vec3d(&mut chunk)?;
+                            let _center = read_vec3d(&mut chunk)?;
+                            let _radius = chunk.read_f32::<LE>()?;
+                            let num_verts = chunk.read_u32::<LE>()?;
+                            let texture = Texturing::Texture(TextureId(chunk.read_u32::<LE>()?));
+                            let verts = read_list_n(num_verts as usize, &mut chunk, |chunk| {
+                                Ok(PolyVertex {
+                                    vertex_id: VertexId(chunk.read_u16::<LE>()?.into()),
+                                    normal_id: NormalId(chunk.read_u16::<LE>()?.into()),
+                                    uv: (chunk.read_f32::<LE>()?, chunk.read_f32::<LE>()?),
+                                })
+                            })?;
+
+                            Polygon { normal, verts, texture }
+                        }
+                        BspData::FLATPOLY => {
+                            let normal = read_vec3d(&mut chunk)?;
+                            let _center = read_vec3d(&mut chunk)?;
+                            let _radius = chunk.read_f32::<LE>()?;
+                            let num_verts = chunk.read_u32::<LE>()?;
+                            let texture = Texturing::Flat(Color {
+                                red: chunk.read_u8()?,
+                                green: chunk.read_u8()?,
+                                blue: chunk.read_u8()?,
+                            });
+                            let _ = chunk.read_u8()?; // get rid of padding byte
+                            let verts = read_list_n(num_verts as usize, &mut chunk, |chunk| {
+                                Ok(PolyVertex {
+                                    vertex_id: VertexId(chunk.read_u16::<LE>()?.into()),
+                                    normal_id: NormalId(chunk.read_u16::<LE>()?.into()),
+                                    uv: Default::default(),
+                                })
+                            })?;
+
+                            Polygon { normal, verts, texture }
+                        }
+                        BspData::ENDOFBRANCH => {
+                            break;
+                        }
+                        _ => {
+                            unreachable!("unknown chunk type! {}", chunk_type);
+                        }
+                    });
+
                     buf = next_chunk;
-                    loop {
-                        let (chunk_type, mut chunk, next_chunk) = parse_chunk_header(buf, false)?;
-                        // keeping looping and pushing new polygons
-                        poly_list.push(match chunk_type {
-                            BspData::TMAPPOLY => {
-                                let normal = read_vec3d(&mut chunk)?;
-                                let _center = read_vec3d(&mut chunk)?;
-                                let _radius = chunk.read_f32::<LE>()?;
-                                let num_verts = chunk.read_u32::<LE>()?;
-                                let texture = Texturing::Texture(TextureId(chunk.read_u32::<LE>()?));
-                                let verts = read_list_n(num_verts as usize, &mut chunk, |chunk| {
-                                    Ok(PolyVertex {
-                                        vertex_id: VertexId(chunk.read_u16::<LE>()?.into()),
-                                        normal_id: NormalId(chunk.read_u16::<LE>()?.into()),
-                                        uv: (chunk.read_f32::<LE>()?, chunk.read_f32::<LE>()?),
-                                    })
-                                })?;
-
-                                Polygon { normal, verts, texture }
-                            }
-                            BspData::FLATPOLY => {
-                                let normal = read_vec3d(&mut chunk)?;
-                                let _center = read_vec3d(&mut chunk)?;
-                                let _radius = chunk.read_f32::<LE>()?;
-                                let num_verts = chunk.read_u32::<LE>()?;
-                                let texture = Texturing::Flat(Color {
-                                    red: chunk.read_u8()?,
-                                    green: chunk.read_u8()?,
-                                    blue: chunk.read_u8()?,
-                                });
-                                let _ = chunk.read_u8()?; // get rid of padding byte
-                                let verts = read_list_n(num_verts as usize, &mut chunk, |chunk| {
-                                    Ok(PolyVertex {
-                                        vertex_id: VertexId(chunk.read_u16::<LE>()?.into()),
-                                        normal_id: NormalId(chunk.read_u16::<LE>()?.into()),
-                                        uv: Default::default(),
-                                    })
-                                })?;
-
-                                Polygon { normal, verts, texture }
-                            }
-                            BspData::ENDOFBRANCH => {
-                                break;
-                            }
-                            _ => {
-                                unreachable!("unknown chunk type! {}", chunk_type);
-                            }
-                        });
-
-                        buf = next_chunk;
-                    }
-                    //assert!(!poly_list.is_empty());
-                    //println!("leaf length {}", poly_list.len());
-                    poly_list
-                },
-            },
+                }
+                //println!("leaf length {}", poly_list.len());
+                match poly_list.len() {
+                    0 => BspNode::Empty,
+                    1 => BspNode::Leaf { bbox, poly: poly_list.into_iter().next().unwrap() },
+                    _ => BspData::recalculate(verts, poly_list.into_iter()),
+                }
+            }
             _ => {
                 unreachable!();
             }
@@ -715,7 +716,7 @@ fn parse_bsp_data(mut buf: &[u8], version: Version) -> io::Result<BspData> {
 
     assert!(num_norms as usize == norms.len());
 
-    let mut bsp_tree = *parse_bsp_node(next_chunk, version)?;
+    let mut bsp_tree = *parse_bsp_node(next_chunk, &verts, version)?;
 
     if version < Version::V20_00 {
         bsp_tree.recalculate_bboxes(&verts);

--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -857,7 +857,6 @@ impl ShieldData {
 #[derive(Clone, Debug)]
 pub struct Polygon {
     pub normal: Vec3d,
-    pub radius: f32,
     pub texture: Texturing,
     pub verts: Vec<PolyVertex>,
 }

--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -865,8 +865,6 @@ pub struct Polygon {
 #[derive(Debug, Clone)]
 pub enum BspNode {
     Split {
-        normal: Vec3d,
-        point: Vec3d,
         bbox: BoundingBox,
         front: Box<BspNode>,
         back: Box<BspNode>,
@@ -1008,8 +1006,6 @@ impl BspData {
                     front: Box::new(recalc_recurse(&mut polygons[..halfpoint])),
                     back: Box::new(recalc_recurse(&mut polygons[halfpoint..])),
                     bbox,
-                    normal: Vec3d::ZERO, // pretty sure these aren't used...
-                    point: Vec3d::ZERO,
                 }
             }
         }

--- a/pof/src/write.rs
+++ b/pof/src/write.rs
@@ -197,11 +197,15 @@ pub(crate) fn write_bsp_data(buf: &mut Vec<u8>, version: Version, bsp_data: &Bsp
                     bbox.sanitize().write_to(buf)?;
                 }
 
-                front_offset.finish(buf);
-                write_bsp_node(buf, verts, version, front)?;
+                if !matches!(**front, BspNode::Empty) {
+                    front_offset.finish(buf);
+                    write_bsp_node(buf, verts, version, front)?;
+                } // otherwise front_offset = 0
 
-                back_offset.finish(buf);
-                write_bsp_node(buf, verts, version, back)?;
+                if !matches!(**back, BspNode::Empty) {
+                    back_offset.finish(buf);
+                    write_bsp_node(buf, verts, version, back)?;
+                } // otherwise back_offset = 0
 
                 chunk_size_pointer.finish(buf);
             }

--- a/pof/src/write.rs
+++ b/pof/src/write.rs
@@ -224,7 +224,7 @@ pub(crate) fn write_bsp_data(buf: &mut Vec<u8>, version: Version, bsp_data: &Bsp
                     poly.normal.write_to(buf)?;
                     let center = Vec3d::average(poly.verts.iter().map(|polyvert| verts[polyvert.vertex_id.0 as usize]));
                     center.write_to(buf)?;
-                    poly.radius.write_to(buf)?;
+                    0f32.write_to(buf)?; // radius: unused
                     (poly.verts.len() as u32).write_to(buf)?;
                     poly.texture.write_to(buf)?;
 

--- a/pof/src/write.rs
+++ b/pof/src/write.rs
@@ -177,13 +177,13 @@ pub(crate) fn write_bsp_data(buf: &mut Vec<u8>, version: Version, bsp_data: &Bsp
 
     fn write_bsp_node(buf: &mut Vec<u8>, verts: &[Vec3d], version: Version, bsp_node: &BspNode) -> io::Result<()> {
         match bsp_node {
-            BspNode::Split { normal, point, bbox, front, back } => {
+            BspNode::Split { bbox, front, back } => {
                 let base = buf.len();
                 buf.write_u32::<LE>(BspData::SORTNORM)?;
                 let chunk_size_pointer = Fixup::new(buf, base)?;
 
-                normal.write_to(buf)?;
-                point.write_to(buf)?;
+                Vec3d::ZERO.write_to(buf)?; // plane_normal: unused
+                Vec3d::ZERO.write_to(buf)?; // plane_point: unused
 
                 buf.write_u32::<LE>(0)?;
 

--- a/pof/src/write.rs
+++ b/pof/src/write.rs
@@ -129,7 +129,7 @@ pub(crate) fn write_shield_node(buf: &mut Vec<u8>, shield_node: &ShieldNode, chu
             write_chunk_type!(ShieldNode::SPLIT)?;
             let chunk_size_pointer = Fixup::new(buf, base)?;
 
-            bbox.write_to(buf)?;
+            bbox.sanitize().write_to(buf)?;
             let front_offset = Fixup::new(buf, base)?;
             let back_offset = Fixup::new(buf, base)?;
 
@@ -146,7 +146,7 @@ pub(crate) fn write_shield_node(buf: &mut Vec<u8>, shield_node: &ShieldNode, chu
             write_chunk_type!(ShieldNode::LEAF)?;
             let chunk_size_pointer = Fixup::new(buf, base)?;
 
-            bbox.write_to(buf)?;
+            bbox.sanitize().write_to(buf)?;
             poly_list.write_to(buf)?;
             chunk_size_pointer.finish(buf);
         }
@@ -194,7 +194,7 @@ pub(crate) fn write_bsp_data(buf: &mut Vec<u8>, version: Version, bsp_data: &Bsp
                 buf.write_u32::<LE>(0)?;
                 buf.write_u32::<LE>(0)?;
                 if version >= Version::V20_00 {
-                    bbox.write_to(buf)?;
+                    bbox.sanitize().write_to(buf)?;
                 }
 
                 front_offset.finish(buf);
@@ -210,7 +210,7 @@ pub(crate) fn write_bsp_data(buf: &mut Vec<u8>, version: Version, bsp_data: &Bsp
                 buf.write_u32::<LE>(BspData::BOUNDBOX)?;
                 let chunk_size_pointer = Fixup::new(buf, base)?;
 
-                bbox.write_to(buf)?;
+                bbox.sanitize().write_to(buf)?;
                 chunk_size_pointer.finish(buf);
 
                 for poly in poly_list {
@@ -357,7 +357,7 @@ impl Model {
                 self.header.max_radius.write_to(w)?;
                 self.header.obj_flags.write_to(w)?;
             }
-            self.header.bbox.write_to(w)?;
+            self.header.bbox.sanitize().write_to(w)?;
             self.header.detail_levels.write_to(w)?;
             self.sub_objects
                 .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,12 +316,10 @@ impl GlObjectBuffers {
 
         let bsp_data = &object.bsp_data;
 
-        for (_, poly_list) in bsp_data.collision_tree.leaves() {
-            for poly in poly_list {
-                match poly.texture {
-                    Texturing::Texture(tex) => textures[tex.0 as usize].push(bsp_data, poly),
-                    Texturing::Flat(_) => no_texture.push(bsp_data, poly),
-                }
+        for (_, poly) in bsp_data.collision_tree.leaves() {
+            match poly.texture {
+                Texturing::Texture(tex) => textures[tex.0 as usize].push(bsp_data, poly),
+                Texturing::Flat(_) => no_texture.push(bsp_data, poly),
             }
         }
 


### PR DESCRIPTION
Since we are planning to drop these vestigial fields in #36 and the current code does not generate `plane_normal` and `plane_point` fields during recalculate anyway, remove these from the data structure and always produce the zero vector in these fields (except for polygon center which is recalculated on the spot on write). This regresses round-tripping for old POF versions, since these fields will no longer be preserved, but we are dropping them from the format because they are unused in the first place.