### PR TITLE
Dont write normal id for no norm polyvertex

### DIFF
--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -618,7 +618,6 @@ pub struct PolyVertex<T = NormalId> {
 impl Serialize for PolyVertex<()> {
     fn write_to(&self, w: &mut impl Write) -> io::Result<()> {
         self.vertex_id.write_to(w)?;
-        0_u16.write_to(w)?;
         self.uv.write_to(w)
     }
 }


### PR DESCRIPTION
`PolyVertex<()>`, used only by insignia, do not write norm ids at all.