### PR TITLE
Fix some turret bugs

### DIFF
--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -942,7 +942,7 @@ trait ParseCtx<'a> {
                         turret.gun_obj = obj_id;
                         turret.base_obj = if name.contains("gun") { parent } else { obj_id };
 
-                        let (pos, norm, _) = node.parse_point(parent_transform, up);
+                        let (pos, norm, _) = node.parse_point(&transform, up);
                         turret.fire_points.push(pos);
                         turret.normal = norm.try_into().unwrap_or_default();
                         continue;

--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -1360,7 +1360,7 @@ impl Default for Turret {
             base_obj: Default::default(),
             gun_obj: Default::default(),
             normal: Default::default(),
-            fire_points: vec![Vec3d::default()],
+            fire_points: vec![],
         }
     }
 }


### PR DESCRIPTION
Turret point transform should be based on the current object, not just its parent and default turrets should not have any fire points.