### PR TITLE
Fix a bug with children of transformed objects

### DIFF
--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -1625,11 +1625,10 @@ impl Model {
         (out_vec, out_idx)
     }
 
-    pub fn do_for_recursive_subobj_children(&self, id: ObjectId, f: &mut impl FnMut(&SubObject)) {
+    pub fn do_for_recursive_subobj_children<'a>(&'a self, id: ObjectId, f: &mut impl FnMut(&'a SubObject)) {
         f(&self.sub_objects[id]);
 
-        let children: Vec<_> = self.sub_objects[id].children().map(|id| *id).collect();
-        for child_id in children {
+        for &child_id in self.sub_objects[id].children() {
             f(&self.sub_objects[child_id]);
             self.do_for_recursive_subobj_children(child_id, f);
         }

--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -1625,6 +1625,16 @@ impl Model {
         (out_vec, out_idx)
     }
 
+    pub fn do_for_recursive_subobj_children(&self, id: ObjectId, f: &mut impl FnMut(&SubObject)) {
+        f(&self.sub_objects[id]);
+
+        let children: Vec<_> = self.sub_objects[id].children().map(|id| *id).collect();
+        for child_id in children {
+            f(&self.sub_objects[child_id]);
+            self.do_for_recursive_subobj_children(child_id, f);
+        }
+    }
+
     pub fn num_debris_objects(&self) -> u32 {
         let mut num_debris = 0;
         for sobj in &self.sub_objects {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1227,17 +1227,11 @@ fn get_list_of_display_subobjects(model: &Model, tree_selection: TreeSelection, 
             top_level_parent = id;
         }
 
-        fn display_subobject_recursive(display_subobjects: &mut ObjVec<bool>, subobjects: &ObjVec<SubObject>, id: ObjectId) {
-            display_subobjects[id] = true;
-
-            for child_id in subobjects[id].children() {
-                if !subobjects[*child_id].is_destroyed_model() {
-                    display_subobject_recursive(display_subobjects, subobjects, *child_id);
-                }
+        model.do_for_recursive_subobj_children(top_level_parent, &mut |subobj| {
+            if !subobj.is_destroyed_model() {
+                out[subobj.obj_id] = true;
             }
-        }
-
-        display_subobject_recursive(&mut out, &model.sub_objects, top_level_parent);
+        });
 
         // if they have debris selected show all the debris
         if model.sub_objects[last_selected_subobj].is_debris_model {

--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -278,17 +278,11 @@ impl UiState {
             match transform_window.transform_type {
                 TransformType::Rotate => {
                     ui.horizontal(|ui| {
-                        if ui.button("X-axis").clicked() {
-                            transform_window.vector = format!("1, 0, 0");
-                        }
+                        ui.selectable_value(&mut transform_window.vector, format!("1, 0, 0"), "X-axis");
                         ui.separator();
-                        if ui.button("Y-axis").clicked() {
-                            transform_window.vector = format!("0, 1, 0");
-                        }
+                        ui.selectable_value(&mut transform_window.vector, format!("0, 1, 0"), "Y-axis");
                         ui.separator();
-                        if ui.button("Z-axis").clicked() {
-                            transform_window.vector = format!("0, 0, 1");
-                        }
+                        ui.selectable_value(&mut transform_window.vector, format!("0, 0, 1"), "Z-axis");
                         ui.separator();
                     });
                     ui.separator();
@@ -1201,7 +1195,9 @@ impl PofToolsGui {
                         self.model.apply_transform(id, &matrix, false);
                         self.ui_state.viewport_3d_dirty = true;
                         properties_panel_dirty = true;
-                        buffer_ids_to_rebuild.push(id);
+
+                        self.model
+                            .do_for_recursive_subobj_children(id, &mut |subobj| buffer_ids_to_rebuild.push(subobj.obj_id));
                     }
                 }
 


### PR DESCRIPTION
Gotta rebuild the buffers for all recursive children. Also add `do_for_recursive_subobj_children()` and some visual tweaks to the transform window