### PR TITLE
Overhaul warnings, and do semantic name linking

### DIFF
--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -1184,9 +1184,9 @@ pub enum NameLink {
     LiveDebrisOf(ObjectId),
     /// Points from the highest detail level object to one of the lower detail levels.
     /// Repeats for each lower detail version; they are in arbitrary order
-    DetailLevel(ObjectId),
+    DetailLevel(ObjectId, u8),
     /// back-link for [`DetailLevel`]: points from lower detail to highest detail version
-    DetailLevelOf(ObjectId),
+    DetailLevelOf(ObjectId, u8),
 }
 
 #[derive(Debug, Clone, Default)]
@@ -2214,9 +2214,10 @@ impl Model {
                     let mut iter = name1.chars().zip(name2.chars()).filter(|(c1, c2)| c1 != c2);
                     // grab the characters that differ and don't continue if there's more than one,
                     // and check that they're 'a' and 'b'..='h' respectively
-                    if let (Some(('a', 'b'..='h')), None) = (iter.next(), iter.next()) {
-                        self.sub_objects[j].name_links.push(NameLink::DetailLevelOf(i));
-                        self.sub_objects[i].name_links.push(NameLink::DetailLevel(j));
+                    if let (Some(('a', ch @ 'b'..='h')), None) = (iter.next(), iter.next()) {
+                        let level = ch as u8 - 'a' as u8;
+                        self.sub_objects[j].name_links.push(NameLink::DetailLevelOf(i, level));
+                        self.sub_objects[i].name_links.push(NameLink::DetailLevel(j, level));
                         name1 = &self.sub_objects[i].name;
                     }
                 }

--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -2209,7 +2209,7 @@ impl Model {
             }
             for j in (0..self.sub_objects.len()).map(|i| ObjectId(i as u32)) {
                 let name2 = &self.sub_objects[j].name;
-                if name1.len() == name2.len() {
+                if name1.len() == name2.len() && self.sub_objects[j].parent.is_some() && self.sub_objects[i].parent.is_some() {
                     // zip them together and filter for equal characters, leaving only the remaining, differing characters
                     let mut iter = name1.chars().zip(name2.chars()).filter(|(c1, c2)| c1 != c2);
                     // grab the characters that differ and don't continue if there's more than one,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ extern crate nalgebra_glm as glm;
 extern crate simplelog;
 
 use crate::ui::{
-    DisplayMode, DockingSelection, EyeSelection, GlowSelection, InsigniaSelection, PathSelection, SpecialPointSelection, SubObjectSelection,
-    TextureSelection, ThrusterSelection, TurretSelection, WeaponSelection,
+    DisplayMode, DockingTreeValue, EyeTreeValue, GlowTreeValue, InsigniaTreeValue, PathTreeValue, SpecialPointTreeValue, SubObjectTreeValue,
+    TextureTreeValue, ThrusterTreeValue, TurretTreeValue, WeaponTreeValue,
 };
 use egui::{Color32, RichText, TextEdit};
 use glium::{
@@ -28,7 +28,7 @@ use std::{
     path::PathBuf,
     sync::mpsc::TryRecvError,
 };
-use ui::{PofToolsGui, Set::*, TreeSelection};
+use ui::{PofToolsGui, TreeValue};
 
 mod primitives;
 mod ui;
@@ -456,9 +456,8 @@ impl PofToolsGui {
 
         self.maybe_recalculate_3d_helpers(display);
 
-        self.warnings.clear();
-        PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All);
-        PofToolsGui::recheck_errors(&mut self.errors, &self.model, All);
+        self.model.recheck_warnings(pof::Set::All);
+        self.model.recheck_errors(pof::Set::All);
         self.ui_state.tree_view_selection = Default::default();
         self.ui_state.refresh_properties_panel(&self.model);
         self.camera_heading = 2.7;
@@ -742,15 +741,15 @@ fn main() {
                     // dim down the bright bits when lollipops are on screen
                     let light_color;
                     match &pt_gui.ui_state.tree_view_selection {
-                        TreeSelection::Thrusters(_)
-                        | TreeSelection::Weapons(_)
-                        | TreeSelection::DockingBays(_)
-                        | TreeSelection::Glows(_)
-                        | TreeSelection::SpecialPoints(_)
-                        | TreeSelection::Turrets(_)
-                        | TreeSelection::Paths(_)
-                        | TreeSelection::EyePoints(_)
-                        | TreeSelection::VisualCenter => {
+                        TreeValue::Thrusters(_)
+                        | TreeValue::Weapons(_)
+                        | TreeValue::DockingBays(_)
+                        | TreeValue::Glows(_)
+                        | TreeValue::SpecialPoints(_)
+                        | TreeValue::Turrets(_)
+                        | TreeValue::Paths(_)
+                        | TreeValue::EyePoints(_)
+                        | TreeValue::VisualCenter => {
                             light_color = [0.3, 0.3, 0.3f32];
                             if pt_gui.display_mode == DisplayMode::Wireframe {
                                 dark_color = [0.05, 0.05, 0.05f32];
@@ -854,10 +853,10 @@ fn main() {
                     }
 
                     // maybe draw the insignias
-                    if let TreeSelection::Insignia(insignia_select) = pt_gui.tree_view_selection {
+                    if let TreeValue::Insignia(insignia_select) = pt_gui.tree_view_selection {
                         let (current_detail_level, current_insignia_idx) = match insignia_select {
-                            InsigniaSelection::Header => (0, None),
-                            InsigniaSelection::Insignia(idx) => (pt_gui.model.insignias[idx].detail_level, Some(idx)),
+                            InsigniaTreeValue::Header => (0, None),
+                            InsigniaTreeValue::Insignia(idx) => (pt_gui.model.insignias[idx].detail_level, Some(idx)),
                         };
 
                         for (i, insig_buffer) in pt_gui.buffer_insignias.iter().enumerate() {
@@ -900,7 +899,7 @@ fn main() {
                     }
 
                     // maybe draw the shield
-                    if let TreeSelection::Shield = pt_gui.tree_view_selection {
+                    if let TreeValue::Shield = pt_gui.tree_view_selection {
                         if let Some(shield) = &pt_gui.buffer_shield {
                             let matrix = view_mat;
                             let norm_matrix: [[f32; 3]; 3] = glm::mat4_to_mat3(&matrix).try_inverse().unwrap().transpose().into();
@@ -955,7 +954,7 @@ fn main() {
                     }
 
                     let mut obj_id = None; // None also indicates the header being possibly selected
-                    if let TreeSelection::SubObjects(SubObjectSelection::SubObject(id)) = pt_gui.tree_view_selection {
+                    if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = pt_gui.tree_view_selection {
                         obj_id = Some(id);
 
                         //      DEBUG - Draw BSP node bounding boxes
@@ -1055,13 +1054,13 @@ fn main() {
                     }
 
                     // don't display lollipops if you're in header or subobjects, unless display_origin is on, since that's the only lollipop they have
-                    let display_lollipops = (!matches!(pt_gui.ui_state.tree_view_selection, TreeSelection::Header)
-                        && !matches!(pt_gui.ui_state.tree_view_selection, TreeSelection::SubObjects(_)))
+                    let display_lollipops = (!matches!(pt_gui.ui_state.tree_view_selection, TreeValue::Header)
+                        && !matches!(pt_gui.ui_state.tree_view_selection, TreeValue::SubObjects(_)))
                         || pt_gui.display_origin;
 
                     if display_lollipops {
                         for lollipop_group in &pt_gui.lollipops {
-                            if let TreeSelection::Paths(_) = pt_gui.ui_state.tree_view_selection {
+                            if let TreeValue::Paths(_) = pt_gui.ui_state.tree_view_selection {
                                 lollipop_params.blend = glium::Blend::alpha_blending();
                             } else {
                                 lollipop_params.blend = ADDITIVE_BLEND;
@@ -1092,7 +1091,7 @@ fn main() {
                                 )
                                 .unwrap();
 
-                            if !matches!(pt_gui.ui_state.tree_view_selection, TreeSelection::Paths(_)) {
+                            if !matches!(pt_gui.ui_state.tree_view_selection, TreeValue::Paths(_)) {
                                 // ...then draw the lollipops with reverse depth order, darker
                                 // this gives the impression that the lollipops are dimly visible through the model
                                 // (dont do it for path lollipops, they're busy enough)
@@ -1207,14 +1206,14 @@ fn main() {
 
 // based on the current selection which submodels should be displayed
 // TODO show destroyed models
-fn get_list_of_display_subobjects(model: &Model, tree_selection: TreeSelection, last_selected_subobj: Option<ObjectId>) -> ObjVec<bool> {
+fn get_list_of_display_subobjects(model: &Model, tree_selection: TreeValue, last_selected_subobj: Option<ObjectId>) -> ObjVec<bool> {
     let mut out = ObjVec(vec![false; model.sub_objects.len()]);
 
     if model.sub_objects.is_empty() {
         return out;
     }
 
-    if let TreeSelection::Insignia(InsigniaSelection::Insignia(idx)) = tree_selection {
+    if let TreeValue::Insignia(InsigniaTreeValue::Insignia(idx)) = tree_selection {
         // show the LOD objects according to the detail level of the currently selected insignia
         for (i, sub_object) in model.sub_objects.iter().enumerate() {
             out.0[i] = model.is_obj_id_ancestor(sub_object.obj_id, model.header.detail_levels[model.insignias[idx].detail_level as usize])
@@ -1257,7 +1256,7 @@ impl PofToolsGui {
         }
 
         // always recalculate for glowpoint sim, TODO maybe make that a little smarter
-        if !(self.ui_state.viewport_3d_dirty || (self.glow_point_simulation && matches!(self.tree_view_selection, TreeSelection::Glows(_)))) {
+        if !(self.ui_state.viewport_3d_dirty || (self.glow_point_simulation && matches!(self.tree_view_selection, TreeValue::Glows(_)))) {
             return;
         }
 
@@ -1279,7 +1278,7 @@ impl PofToolsGui {
         // push the according lollipop positions/normals based on the points positions/normals
         // push into 3 separate vectors, for 3 separate colors depending on selection state
         match self.ui_state.tree_view_selection {
-            TreeSelection::SubObjects(SubObjectSelection::SubObject(obj_id)) => {
+            TreeValue::SubObjects(SubObjectTreeValue::SubObject(obj_id)) => {
                 for buffers in &mut self.buffer_objects {
                     if buffers.obj_id == obj_id {
                         for buffer in &mut buffers.buffers {
@@ -1296,7 +1295,7 @@ impl PofToolsGui {
                     self.lollipops = vec![lollipop_origin];
                 }
             }
-            TreeSelection::Textures(TextureSelection::Texture(tex)) => {
+            TreeValue::Textures(TextureTreeValue::Texture(tex)) => {
                 for buffers in &mut self.buffer_objects {
                     for buffer in &mut buffers.buffers {
                         if buffer.texture_id == Some(tex) {
@@ -1305,12 +1304,12 @@ impl PofToolsGui {
                     }
                 }
             }
-            TreeSelection::Thrusters(thruster_selection) => {
+            TreeValue::Thrusters(thruster_selection) => {
                 let mut selected_bank = None;
                 let mut selected_point = None;
                 match thruster_selection {
-                    ThrusterSelection::Bank(bank) => selected_bank = Some(bank),
-                    ThrusterSelection::BankPoint(bank, point) => {
+                    ThrusterTreeValue::Bank(bank) => selected_bank = Some(bank),
+                    ThrusterTreeValue::BankPoint(bank, point) => {
                         selected_bank = Some(bank);
                         selected_point = Some(point);
                     }
@@ -1340,33 +1339,33 @@ impl PofToolsGui {
                     }),
                 );
             }
-            TreeSelection::Weapons(weapons_selection) => {
+            TreeValue::Weapons(weapons_selection) => {
                 let mut selected_bank = None;
                 let mut selected_point = None;
                 let mut selected_weapon_system = None;
                 match weapons_selection {
-                    WeaponSelection::PriBank(bank) => {
+                    WeaponTreeValue::PriBank(bank) => {
                         selected_bank = Some(bank);
                         selected_weapon_system = Some(&model.primary_weps);
                     }
-                    WeaponSelection::SecBank(bank) => {
+                    WeaponTreeValue::SecBank(bank) => {
                         selected_bank = Some(bank);
                         selected_weapon_system = Some(&model.secondary_weps);
                     }
-                    WeaponSelection::PriBankPoint(bank, point) => {
+                    WeaponTreeValue::PriBankPoint(bank, point) => {
                         selected_bank = Some(bank);
                         selected_point = Some(point);
                         selected_weapon_system = Some(&model.primary_weps);
                     }
-                    WeaponSelection::SecBankPoint(bank, point) => {
+                    WeaponTreeValue::SecBankPoint(bank, point) => {
                         selected_bank = Some(bank);
                         selected_point = Some(point);
                         selected_weapon_system = Some(&model.secondary_weps);
                     }
-                    WeaponSelection::PriHeader => {
+                    WeaponTreeValue::PriHeader => {
                         selected_weapon_system = Some(&model.primary_weps);
                     }
-                    WeaponSelection::SecHeader => {
+                    WeaponTreeValue::SecHeader => {
                         selected_weapon_system = Some(&model.secondary_weps);
                     }
                     _ => {}
@@ -1401,8 +1400,8 @@ impl PofToolsGui {
                     }),
                 );
             }
-            TreeSelection::DockingBays(docking_selection) => {
-                let selected_bank = if let DockingSelection::Bay(num) = docking_selection {
+            TreeValue::DockingBays(docking_selection) => {
+                let selected_bank = if let DockingTreeValue::Bay(num) = docking_selection {
                     Some(num)
                 } else {
                     None
@@ -1434,12 +1433,12 @@ impl PofToolsGui {
                     }),
                 );
             }
-            TreeSelection::Glows(glow_selection) => {
+            TreeValue::Glows(glow_selection) => {
                 let mut selected_bank = None;
                 let mut selected_point = None;
                 match glow_selection {
-                    GlowSelection::Bank(bank) => selected_bank = Some(bank),
-                    GlowSelection::BankPoint(bank, point) => {
+                    GlowTreeValue::Bank(bank) => selected_bank = Some(bank),
+                    GlowTreeValue::BankPoint(bank, point) => {
                         selected_bank = Some(bank);
                         selected_point = Some(point);
                     }
@@ -1474,9 +1473,9 @@ impl PofToolsGui {
                     }),
                 );
             }
-            TreeSelection::SpecialPoints(special_selection) => {
+            TreeValue::SpecialPoints(special_selection) => {
                 let mut selected_point = None;
-                if let SpecialPointSelection::Point(point) = special_selection {
+                if let SpecialPointTreeValue::Point(point) = special_selection {
                     selected_point = Some(point);
                 }
 
@@ -1493,12 +1492,12 @@ impl PofToolsGui {
                     }),
                 );
             }
-            TreeSelection::Turrets(turret_selection) => {
+            TreeValue::Turrets(turret_selection) => {
                 let mut selected_turret = None;
                 let mut selected_point = None;
                 match turret_selection {
-                    TurretSelection::Turret(turret) => selected_turret = Some(turret),
-                    TurretSelection::TurretPoint(turret, point) => {
+                    TurretTreeValue::Turret(turret) => selected_turret = Some(turret),
+                    TurretTreeValue::TurretPoint(turret, point) => {
                         selected_turret = Some(turret);
                         selected_point = Some(point);
                     }
@@ -1531,12 +1530,12 @@ impl PofToolsGui {
                     }),
                 );
             }
-            TreeSelection::Paths(path_selection) => {
+            TreeValue::Paths(path_selection) => {
                 let mut selected_path = None;
                 let mut selected_point = None;
                 match path_selection {
-                    PathSelection::Path(path) => selected_path = Some(path),
-                    PathSelection::PathPoint(path, point) => {
+                    PathTreeValue::Path(path) => selected_path = Some(path),
+                    PathTreeValue::PathPoint(path, point) => {
                         selected_path = Some(path);
                         selected_point = Some(point);
                     }
@@ -1576,9 +1575,9 @@ impl PofToolsGui {
                     }),
                 );
             }
-            TreeSelection::EyePoints(eye_selection) => {
+            TreeValue::EyePoints(eye_selection) => {
                 let mut selected_eye = None;
-                if let EyeSelection::EyePoint(point) = eye_selection {
+                if let EyeTreeValue::EyePoint(point) = eye_selection {
                     selected_eye = Some(point)
                 }
 
@@ -1597,7 +1596,7 @@ impl PofToolsGui {
                     }),
                 );
             }
-            TreeSelection::VisualCenter => {
+            TreeValue::VisualCenter => {
                 let size = 0.02 * model.header.max_radius;
 
                 let mut lollipop_origin = GlLollipopsBuilder::new(LOLLIPOP_SELECTED_BANK_COLOR);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -71,9 +71,12 @@ impl TreeValue {
     // returns what, if any, tree_value best corresponds to a given warning
     fn from_warning(warning: Warning) -> Option<TreeValue> {
         match warning {
-            Warning::RadiusTooSmall(id_opt) => Some(TreeValue::SubObjects(SubObjectTreeValue::subobject(id_opt))),
-            Warning::BBoxTooSmall(id_opt) => Some(TreeValue::SubObjects(SubObjectTreeValue::subobject(id_opt))),
-            Warning::InvertedBBox(id_opt) => Some(TreeValue::SubObjects(SubObjectTreeValue::subobject(id_opt))),
+            Warning::RadiusTooSmall(None) => Some(TreeValue::Header),
+            Warning::BBoxTooSmall(None) => Some(TreeValue::Header),
+            Warning::InvertedBBox(None) => Some(TreeValue::Header),
+            Warning::RadiusTooSmall(Some(id)) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(id))),
+            Warning::BBoxTooSmall(Some(id)) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(id))),
+            Warning::InvertedBBox(Some(id)) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(id))),
             Warning::UntexturedPolygons => None,
             Warning::DockingBayWithoutPath(idx) => Some(TreeValue::DockingBays(DockingTreeValue::Bay(idx))),
             Warning::ThrusterPropertiesInvalidVersion(idx) => Some(TreeValue::Thrusters(ThrusterTreeValue::Bank(idx))),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -539,7 +539,9 @@ impl UiState {
                             return text.color(Color32::LIGHT_RED)
                         }
                         pof::NameLink::LiveDebris(id) | pof::NameLink::LiveDebrisOf(id) if id == selected_id => return text.color(LIGHT_ORANGE),
-                        pof::NameLink::DetailLevel(id) | pof::NameLink::DetailLevelOf(id) if id == selected_id => return text.color(LIGHT_BLUE),
+                        pof::NameLink::DetailLevel(id, _) | pof::NameLink::DetailLevelOf(id, _) if id == selected_id => {
+                            return text.color(LIGHT_BLUE)
+                        }
                         _ => {}
                     }
                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -697,8 +697,8 @@ impl PofToolsGui {
         });
         let mut warnings = egui::TopBottomPanel::bottom("info bar")
             .resizable(true)
-            .default_height(16.0)
-            .height_range(16.0..=500.0)
+            .default_height(23.0)
+            .height_range(23.0..=500.0)
             .show(ctx, |ui| {
                 egui::ScrollArea::vertical()
                     .auto_shrink([false, false])

--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -4,13 +4,13 @@ use egui::{style::Widgets, text::LayoutJob, CollapsingHeader, Color32, DragValue
 use glium::Display;
 use nalgebra_glm::TMat4;
 use pof::{
-    Dock, EyePoint, GlowPoint, GlowPointBank, Insignia, Model, ObjectId, PathId, PathPoint, SpecialPoint, SubsysMovementAxis, SubsysMovementType,
-    ThrusterGlow, Vec3d, WeaponHardpoint,
+    Dock, Error, EyePoint, GlowPoint, GlowPointBank, Insignia, Model, ObjectId, PathId, PathPoint, Set::*, SpecialPoint, SubsysMovementAxis,
+    SubsysMovementType, ThrusterGlow, Vec3d, Warning, WeaponHardpoint,
 };
 
 use crate::ui::{
-    DockingSelection, Error, EyeSelection, GlowSelection, InsigniaSelection, PathSelection, PofToolsGui, Set::*, SpecialPointSelection,
-    SubObjectSelection, TextureSelection, ThrusterSelection, TreeSelection, TurretSelection, UiState, Warning, WeaponSelection,
+    DockingTreeValue, EyeTreeValue, GlowTreeValue, InsigniaTreeValue, PathTreeValue, PofToolsGui, SpecialPointTreeValue, SubObjectTreeValue,
+    TextureTreeValue, ThrusterTreeValue, TreeValue, TurretTreeValue, UiState, WeaponTreeValue, LIGHT_BLUE, LIGHT_ORANGE,
 };
 
 enum IndexingButtonsResponse {
@@ -373,7 +373,7 @@ impl UiState {
     // fills the properties panel based on the current tree selection, taking all the relevant data from the model
     pub(crate) fn refresh_properties_panel(&mut self, model: &Model) {
         match self.tree_view_selection {
-            TreeSelection::Header => {
+            TreeValue::Header => {
                 self.properties_panel = PropertiesPanel::Header {
                     bbox_min_string: format!("{}", model.header.bbox.min),
                     bbox_max_string: format!("{}", model.header.bbox.max),
@@ -394,9 +394,9 @@ impl UiState {
                     transform_window: Default::default(),
                 }
             }
-            TreeSelection::SubObjects(subobj_tree_select) => match subobj_tree_select {
-                SubObjectSelection::Header => self.properties_panel = PropertiesPanel::default_subobject(),
-                SubObjectSelection::SubObject(id) => {
+            TreeValue::SubObjects(subobj_tree_select) => match subobj_tree_select {
+                SubObjectTreeValue::Header => self.properties_panel = PropertiesPanel::default_subobject(),
+                SubObjectTreeValue::SubObject(id) => {
                     self.properties_panel = PropertiesPanel::SubObject {
                         bbox_max_string: format!("{}", model.sub_objects[id].bbox.max),
                         bbox_min_string: format!("{}", model.sub_objects[id].bbox.min),
@@ -409,17 +409,17 @@ impl UiState {
                     }
                 }
             },
-            TreeSelection::Textures(tex_tree_select) => match tex_tree_select {
-                TextureSelection::Header => self.properties_panel = PropertiesPanel::default_texture(),
-                TextureSelection::Texture(texture_id) => {
+            TreeValue::Textures(tex_tree_select) => match tex_tree_select {
+                TextureTreeValue::Header => self.properties_panel = PropertiesPanel::default_texture(),
+                TextureTreeValue::Texture(texture_id) => {
                     self.properties_panel = PropertiesPanel::Texture {
                         texture_name: format!("{}", model.textures[texture_id.0 as usize]),
                     }
                 }
             },
-            TreeSelection::Thrusters(thruster_tree_select) => match thruster_tree_select {
-                ThrusterSelection::Header => self.properties_panel = PropertiesPanel::default_thruster(),
-                ThrusterSelection::Bank(bank) => {
+            TreeValue::Thrusters(thruster_tree_select) => match thruster_tree_select {
+                ThrusterTreeValue::Header => self.properties_panel = PropertiesPanel::default_thruster(),
+                ThrusterTreeValue::Bank(bank) => {
                     self.properties_panel = PropertiesPanel::Thruster {
                         engine_subsys_string: format!(
                             "{}",
@@ -430,7 +430,7 @@ impl UiState {
                         position_string: Default::default(),
                     }
                 }
-                ThrusterSelection::BankPoint(bank, point) => {
+                ThrusterTreeValue::BankPoint(bank, point) => {
                     self.properties_panel = PropertiesPanel::Thruster {
                         engine_subsys_string: format!(
                             "{}",
@@ -442,15 +442,15 @@ impl UiState {
                     }
                 }
             },
-            TreeSelection::Weapons(weapons_tree_select) => match weapons_tree_select {
-                WeaponSelection::PriBankPoint(bank_idx, point_idx) => {
+            TreeValue::Weapons(weapons_tree_select) => match weapons_tree_select {
+                WeaponTreeValue::PriBankPoint(bank_idx, point_idx) => {
                     self.properties_panel = PropertiesPanel::Weapon {
                         position_string: format!("{}", model.primary_weps[bank_idx][point_idx].position),
                         normal_string: format!("{}", model.primary_weps[bank_idx][point_idx].normal.0),
                         offset_string: format!("{}", model.primary_weps[bank_idx][point_idx].offset),
                     }
                 }
-                WeaponSelection::SecBankPoint(bank_idx, point_idx) => {
+                WeaponTreeValue::SecBankPoint(bank_idx, point_idx) => {
                     self.properties_panel = PropertiesPanel::Weapon {
                         position_string: format!("{}", model.secondary_weps[bank_idx][point_idx].position),
                         normal_string: format!("{}", model.secondary_weps[bank_idx][point_idx].normal.0),
@@ -459,8 +459,8 @@ impl UiState {
                 }
                 _ => self.properties_panel = PropertiesPanel::default_weapon(),
             },
-            TreeSelection::DockingBays(docking_select) => match docking_select {
-                DockingSelection::Bay(bay) => {
+            TreeValue::DockingBays(docking_select) => match docking_select {
+                DockingTreeValue::Bay(bay) => {
                     self.properties_panel = PropertiesPanel::DockingBay {
                         name_string: pof::properties_get_field(&model.docking_bays[bay].properties, "$name")
                             .map_or(format!("Dock {}", bay + 1), |name| format!("{}", name)),
@@ -472,8 +472,8 @@ impl UiState {
                 }
                 _ => self.properties_panel = PropertiesPanel::default_docking_bay(),
             },
-            TreeSelection::Glows(glow_select) => match glow_select {
-                GlowSelection::BankPoint(bank, point) => {
+            TreeValue::Glows(glow_select) => match glow_select {
+                GlowTreeValue::BankPoint(bank, point) => {
                     self.properties_panel = PropertiesPanel::GlowBank {
                         disp_time_string: format!("{}", model.glow_banks[bank].disp_time),
                         on_time_string: format!("{}", model.glow_banks[bank].on_time),
@@ -490,7 +490,7 @@ impl UiState {
                         radius_string: format!("{}", model.glow_banks[bank].glow_points[point].radius),
                     }
                 }
-                GlowSelection::Bank(bank) => {
+                GlowTreeValue::Bank(bank) => {
                     self.properties_panel = PropertiesPanel::GlowBank {
                         disp_time_string: format!("{}", model.glow_banks[bank].disp_time),
                         on_time_string: format!("{}", model.glow_banks[bank].on_time),
@@ -509,8 +509,8 @@ impl UiState {
                 }
                 _ => self.properties_panel = PropertiesPanel::default_glow(),
             },
-            TreeSelection::SpecialPoints(special_select) => match special_select {
-                SpecialPointSelection::Point(point) => {
+            TreeValue::SpecialPoints(special_select) => match special_select {
+                SpecialPointTreeValue::Point(point) => {
                     self.properties_panel = PropertiesPanel::SpecialPoint {
                         name_string: format!("{}", model.special_points[point].name),
                         position_string: format!("{}", model.special_points[point].position),
@@ -519,15 +519,15 @@ impl UiState {
                 }
                 _ => self.properties_panel = PropertiesPanel::default_special_point(),
             },
-            TreeSelection::Turrets(turret_selection) => match turret_selection {
-                TurretSelection::TurretPoint(turret, point) => {
+            TreeValue::Turrets(turret_selection) => match turret_selection {
+                TurretTreeValue::TurretPoint(turret, point) => {
                     self.properties_panel = PropertiesPanel::Turret {
                         normal_string: format!("{}", model.turrets[turret].normal.0),
                         base_idx: model.turrets[turret].base_obj.0 as usize,
                         position_string: format!("{}", model.turrets[turret].fire_points[point]),
                     }
                 }
-                TurretSelection::Turret(turret) => {
+                TurretTreeValue::Turret(turret) => {
                     self.properties_panel = PropertiesPanel::Turret {
                         normal_string: format!("{}", model.turrets[turret].normal.0),
                         base_idx: model.turrets[turret].base_obj.0 as usize,
@@ -536,8 +536,8 @@ impl UiState {
                 }
                 _ => self.properties_panel = PropertiesPanel::default_turret(),
             },
-            TreeSelection::Paths(path_selection) => match path_selection {
-                PathSelection::PathPoint(path, point) => {
+            TreeValue::Paths(path_selection) => match path_selection {
+                PathTreeValue::PathPoint(path, point) => {
                     self.properties_panel = PropertiesPanel::Path {
                         name: format!("{}", model.paths[path].name),
                         parent_string: format!("{}", model.paths[path].parent),
@@ -545,7 +545,7 @@ impl UiState {
                         radius_string: format!("{}", model.paths[path].points[point].radius),
                     }
                 }
-                PathSelection::Path(path) => {
+                PathTreeValue::Path(path) => {
                     self.properties_panel = PropertiesPanel::Path {
                         name: format!("{}", model.paths[path].name),
                         parent_string: format!("{}", model.paths[path].parent),
@@ -555,8 +555,8 @@ impl UiState {
                 }
                 _ => self.properties_panel = PropertiesPanel::default_path(),
             },
-            TreeSelection::Insignia(insig_selection) => match insig_selection {
-                InsigniaSelection::Insignia(idx) => {
+            TreeValue::Insignia(insig_selection) => match insig_selection {
+                InsigniaTreeValue::Insignia(idx) => {
                     self.properties_panel = PropertiesPanel::Insignia {
                         lod_string: format!("{}", model.insignias[idx].detail_level),
                         offset_string: format!("{}", model.insignias[idx].offset),
@@ -564,8 +564,8 @@ impl UiState {
                 }
                 _ => self.properties_panel = PropertiesPanel::default_insignia(),
             },
-            TreeSelection::EyePoints(eye_selection) => match eye_selection {
-                EyeSelection::EyePoint(idx) => {
+            TreeValue::EyePoints(eye_selection) => match eye_selection {
+                EyeTreeValue::EyePoint(idx) => {
                     self.properties_panel = PropertiesPanel::EyePoint {
                         position_string: format!("{}", model.eye_points[idx].offset),
                         normal_string: format!("{}", model.eye_points[idx].normal.0),
@@ -574,9 +574,9 @@ impl UiState {
                 }
                 _ => self.properties_panel = PropertiesPanel::default_eye(),
             },
-            TreeSelection::Shield => self.properties_panel = PropertiesPanel::Shield, // nothing mutable to refresh! woohoo!'
-            TreeSelection::VisualCenter => self.properties_panel = PropertiesPanel::VisualCenter { position: format!("{}", model.visual_center) },
-            TreeSelection::Comments => self.properties_panel = PropertiesPanel::Comments,
+            TreeValue::Shield => self.properties_panel = PropertiesPanel::Shield, // nothing mutable to refresh! woohoo!'
+            TreeValue::VisualCenter => self.properties_panel = PropertiesPanel::VisualCenter { position: format!("{}", model.visual_center) },
+            TreeValue::Comments => self.properties_panel = PropertiesPanel::Comments,
         }
     }
 }
@@ -847,7 +847,7 @@ impl PofToolsGui {
                     let response = UiState::model_value_edit(
                         &mut self.ui_state.viewport_3d_dirty,
                         ui,
-                        self.warnings.contains(&Warning::BBoxTooSmall(None)),
+                        self.model.warnings.contains(&Warning::BBoxTooSmall(None)),
                         Some(&mut self.model.header.bbox.min),
                         bbox_min_string,
                     );
@@ -863,7 +863,7 @@ impl PofToolsGui {
                     let response = UiState::model_value_edit(
                         &mut self.ui_state.viewport_3d_dirty,
                         ui,
-                        self.warnings.contains(&Warning::BBoxTooSmall(None)),
+                        self.model.warnings.contains(&Warning::BBoxTooSmall(None)),
                         Some(&mut self.model.header.bbox.max),
                         bbox_max_string,
                     );
@@ -891,7 +891,7 @@ impl PofToolsGui {
                 let response = UiState::model_value_edit(
                     &mut self.ui_state.viewport_3d_dirty,
                     ui,
-                    self.warnings.contains(&Warning::RadiusTooSmall(None)),
+                    self.model.warnings.contains(&Warning::RadiusTooSmall(None)),
                     Some(&mut self.model.header.max_radius),
                     radius_string,
                 );
@@ -940,11 +940,11 @@ impl PofToolsGui {
                 );
 
                 if radius_changed {
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::RadiusTooSmall(None)));
+                    self.model.recheck_warnings(One(Warning::RadiusTooSmall(None)));
                 }
                 if bbox_changed {
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::BBoxTooSmall(None)));
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::InvertedBBox(None)));
+                    self.model.recheck_warnings(One(Warning::BBoxTooSmall(None)));
+                    self.model.recheck_warnings(One(Warning::InvertedBBox(None)));
                 }
 
                 ui.separator();
@@ -993,7 +993,7 @@ impl PofToolsGui {
                 ui.heading("SubObject");
                 ui.separator();
 
-                let selected_id = if let TreeSelection::SubObjects(SubObjectSelection::SubObject(id)) = self.ui_state.tree_view_selection {
+                let selected_id = if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = self.ui_state.tree_view_selection {
                     Some(id)
                 } else {
                     None
@@ -1004,7 +1004,8 @@ impl PofToolsGui {
                 ui.label("Name:");
                 if let Some(id) = selected_id {
                     if ui.add(egui::TextEdit::singleline(&mut self.model.sub_objects[id].name)).changed() {
-                        PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::SubObjectNameTooLong(id)));
+                        self.model.recheck_warnings(One(Warning::SubObjectNameTooLong(id)));
+                        self.model.recalc_semantic_name_links();
                     }
                 } else {
                     ui.add_enabled(false, egui::TextEdit::singleline(name));
@@ -1038,8 +1039,8 @@ impl PofToolsGui {
 
                     if checkbox.changed() {
                         self.model.sub_objects[selected_id.unwrap()].is_debris_model = *is_debris_check;
-                        PofToolsGui::recheck_errors(&mut self.errors, &self.model, One(Error::TooManyDebrisObjects));
-                        PofToolsGui::recheck_errors(&mut self.errors, &self.model, One(Error::DetailAndDebrisObj(selected_id.unwrap())));
+                        self.model.recheck_errors(One(Error::TooManyDebrisObjects));
+                        self.model.recheck_errors(One(Error::DetailAndDebrisObj(selected_id.unwrap())));
                     }
 
                     UiState::reset_widget_color(ui);
@@ -1098,8 +1099,8 @@ impl PofToolsGui {
                 self.ui_state.display_bbox = display_bbox;
 
                 if bbox_changed {
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::BBoxTooSmall(selected_id)));
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::InvertedBBox(selected_id)));
+                    self.model.recheck_warnings(One(Warning::BBoxTooSmall(selected_id)));
+                    self.model.recheck_warnings(One(Warning::InvertedBBox(selected_id)));
                 }
 
                 ui.add_space(5.0);
@@ -1112,7 +1113,7 @@ impl PofToolsGui {
 
                     if response.clicked() {
                         self.model.recalc_subobj_offset(selected_id.unwrap());
-                        PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::RadiusTooSmall(selected_id)));
+                        self.model.recheck_warnings(One(Warning::RadiusTooSmall(selected_id)));
 
                         self.ui_state.viewport_3d_dirty = true;
                         buffer_ids_to_rebuild.push(selected_id.unwrap());
@@ -1172,7 +1173,7 @@ impl PofToolsGui {
                 let response = UiState::model_value_edit(
                     &mut self.ui_state.viewport_3d_dirty,
                     ui,
-                    self.warnings.contains(&Warning::RadiusTooSmall(selected_id)),
+                    self.model.warnings.contains(&Warning::RadiusTooSmall(selected_id)),
                     selected_id.map(|id| &mut self.model.sub_objects[id].radius),
                     radius_string,
                 );
@@ -1183,7 +1184,7 @@ impl PofToolsGui {
                 self.ui_state.display_radius = response.hovered() || response.has_focus() || display_radius;
 
                 if radius_changed {
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::RadiusTooSmall(selected_id)));
+                    self.model.recheck_warnings(One(Warning::RadiusTooSmall(selected_id)));
                 }
 
                 ui.separator();
@@ -1239,7 +1240,7 @@ impl PofToolsGui {
 
                     //Error::InvalidTurretGunSubobject(())
                     //Error::DetailObjWithParent(())
-                    PofToolsGui::recheck_errors(&mut self.errors, &self.model, All);
+                    self.model.recheck_errors(All);
                 }
 
                 // Properties edit ================================================================
@@ -1250,7 +1251,7 @@ impl PofToolsGui {
                         .add(egui::TextEdit::multiline(&mut self.model.sub_objects[id].properties).desired_rows(2))
                         .changed()
                     {
-                        PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::SubObjectPropertiesTooLong(id)));
+                        self.model.recheck_warnings(One(Warning::SubObjectPropertiesTooLong(id)));
                     }
                 } else {
                     ui.add_enabled(false, egui::TextEdit::multiline(&mut blank_string).desired_rows(2));
@@ -1294,16 +1295,111 @@ impl PofToolsGui {
                 //     );
                 // }
 
+                // Semantic name links ================================================================
+
+                if let Some(id) = selected_id {
+                    let subobj = &self.model.sub_objects[id];
+                    if subobj.detail_level_of.is_some()
+                        || !subobj.detail_levels.is_empty()
+                        || subobj.live_debris_of.is_some()
+                        || !subobj.live_debris.is_empty()
+                        || subobj.destroyed_version.is_some()
+                        || subobj.intact_version.is_some()
+                    {
+                        ui.separator();
+
+                        if let Some(destroyed_id) = subobj.destroyed_version {
+                            ui.horizontal_wrapped(|ui| {
+                                ui.label(RichText::new(format!("Has a destroyed version:")).weak().color(Color32::LIGHT_RED));
+                                if ui
+                                    .button(RichText::new(&self.model.sub_objects[destroyed_id].name).weak().color(Color32::LIGHT_RED))
+                                    .clicked()
+                                {
+                                    self.ui_state.tree_view_selection = TreeValue::SubObjects(SubObjectTreeValue::SubObject(destroyed_id));
+                                    properties_panel_dirty = true;
+                                    self.ui_state.viewport_3d_dirty = true;
+                                }
+                            });
+                        } else if let Some(intact_id) = subobj.intact_version {
+                            ui.horizontal_wrapped(|ui| {
+                                ui.label(RichText::new(format!("Is the destroyed version of: ")).weak().color(Color32::LIGHT_RED));
+                                if ui
+                                    .button(RichText::new(&self.model.sub_objects[intact_id].name).weak().color(Color32::LIGHT_RED))
+                                    .clicked()
+                                {
+                                    self.ui_state.tree_view_selection = TreeValue::SubObjects(SubObjectTreeValue::SubObject(intact_id));
+                                    properties_panel_dirty = true;
+                                    self.ui_state.viewport_3d_dirty = true;
+                                }
+                            });
+                        }
+
+                        if !subobj.live_debris.is_empty() {
+                            ui.label(RichText::new(format!("Has sub-debris objects:")).weak().color(LIGHT_ORANGE));
+                            for &id in &subobj.live_debris {
+                                if ui
+                                    .button(RichText::new(&self.model.sub_objects[id].name).weak().color(LIGHT_ORANGE))
+                                    .clicked()
+                                {
+                                    self.ui_state.tree_view_selection = TreeValue::SubObjects(SubObjectTreeValue::SubObject(id));
+                                    properties_panel_dirty = true;
+                                    self.ui_state.viewport_3d_dirty = true;
+                                }
+                            }
+                        } else if let Some(debris_parent_id) = subobj.live_debris_of {
+                            ui.horizontal_wrapped(|ui| {
+                                ui.label(RichText::new(format!("Is a debris object of: ")).weak().color(LIGHT_ORANGE));
+                                if ui
+                                    .button(RichText::new(&self.model.sub_objects[debris_parent_id].name).weak().color(LIGHT_ORANGE))
+                                    .clicked()
+                                {
+                                    self.ui_state.tree_view_selection = TreeValue::SubObjects(SubObjectTreeValue::SubObject(debris_parent_id));
+                                    properties_panel_dirty = true;
+                                    self.ui_state.viewport_3d_dirty = true;
+                                }
+                            });
+                        }
+
+                        if !subobj.detail_levels.is_empty() {
+                            ui.label(RichText::new(format!("Has detail level objects:")).weak().color(LIGHT_BLUE));
+                            for &id in &subobj.detail_levels {
+                                if ui
+                                    .button(RichText::new(&self.model.sub_objects[id].name).weak().color(LIGHT_BLUE))
+                                    .clicked()
+                                {
+                                    self.ui_state.tree_view_selection = TreeValue::SubObjects(SubObjectTreeValue::SubObject(id));
+                                    properties_panel_dirty = true;
+                                    self.ui_state.viewport_3d_dirty = true;
+                                }
+                            }
+                        } else if let Some(detail_parent_id) = subobj.detail_level_of {
+                            ui.horizontal_wrapped(|ui| {
+                                ui.label(RichText::new(format!("Is a detail object of: ")).weak().color(LIGHT_BLUE));
+                                if ui
+                                    .button(RichText::new(&self.model.sub_objects[detail_parent_id].name).weak().color(LIGHT_BLUE))
+                                    .clicked()
+                                {
+                                    self.ui_state.tree_view_selection = TreeValue::SubObjects(SubObjectTreeValue::SubObject(detail_parent_id));
+                                    properties_panel_dirty = true;
+                                    self.ui_state.viewport_3d_dirty = true;
+                                }
+                            });
+                        }
+                    }
+                }
+
+                // Misc stats ================================================================
+
                 ui.separator();
 
                 if let Some(id) = selected_id {
                     ui.label(RichText::new(format!("Id: {:?}", self.model.sub_objects[id].obj_id)).weak());
                     let mut vert_string = RichText::new(format!("Vertices: {}", self.model.sub_objects[id].bsp_data.verts.len())).weak();
-                    if self.errors.contains(&Error::TooManyVerts(id)) {
+                    if self.model.errors.contains(&Error::TooManyVerts(id)) {
                         vert_string = vert_string.color(Color32::RED);
                     }
                     let mut norm_string = RichText::new(format!("Normals: {}", self.model.sub_objects[id].bsp_data.norms.len())).weak();
-                    if self.errors.contains(&Error::TooManyNorms(id)) {
+                    if self.model.errors.contains(&Error::TooManyNorms(id)) {
                         norm_string = norm_string.color(Color32::RED);
                     }
                     ui.label(vert_string);
@@ -1322,7 +1418,7 @@ impl PofToolsGui {
                 });
                 ui.separator();
 
-                let tex = if let TreeSelection::Textures(TextureSelection::Texture(tex)) = self.ui_state.tree_view_selection {
+                let tex = if let TreeValue::Textures(TextureTreeValue::Texture(tex)) = self.ui_state.tree_view_selection {
                     Some(&mut self.model.textures[tex.0 as usize])
                 } else {
                     None
@@ -1331,10 +1427,10 @@ impl PofToolsGui {
                 ui.label("Texture Name:");
                 if UiState::model_value_edit(&mut self.ui_state.viewport_3d_dirty, ui, false, tex, texture_name).changed()
                     && self.model.untextured_idx.is_some()
-                    && self.ui_state.tree_view_selection == TreeSelection::Textures(TextureSelection::Texture(self.model.untextured_idx.unwrap()))
+                    && self.ui_state.tree_view_selection == TreeValue::Textures(TextureTreeValue::Texture(self.model.untextured_idx.unwrap()))
                 {
                     self.model.untextured_idx = None;
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::UntexturedPolygons));
+                    self.model.recheck_warnings(One(Warning::UntexturedPolygons));
                 }
             }
             PropertiesPanel::Thruster {
@@ -1347,8 +1443,8 @@ impl PofToolsGui {
                 ui.separator();
 
                 let (bank_num, point_num) = match self.ui_state.tree_view_selection {
-                    TreeSelection::Thrusters(ThrusterSelection::Bank(bank)) => (Some(bank), None),
-                    TreeSelection::Thrusters(ThrusterSelection::BankPoint(bank, point)) => (Some(bank), Some(point)),
+                    TreeValue::Thrusters(ThrusterTreeValue::Bank(bank)) => (Some(bank), None),
+                    TreeValue::Thrusters(ThrusterTreeValue::BankPoint(bank, point)) => (Some(bank), Some(point)),
                     _ => (None, None),
                 };
 
@@ -1359,13 +1455,13 @@ impl PofToolsGui {
                 ui.horizontal(|ui| {
                     ui.label("Engine Subsystem:");
                     if let Some(bank) = bank_num {
-                        if self.warnings.contains(&Warning::ThrusterPropertiesInvalidVersion(bank)) {
+                        if self.model.warnings.contains(&Warning::ThrusterPropertiesInvalidVersion(bank)) {
                             UiState::set_widget_color(ui, Color32::YELLOW);
                         }
                         if ui.text_edit_singleline(engine_subsys_string).changed() {
                             pof::properties_update_field(&mut self.model.thruster_banks[bank].properties, "$engine_subsystem", engine_subsys_string);
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::ThrusterPropertiesTooLong(bank)));
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::ThrusterPropertiesInvalidVersion(bank)));
+                            self.model.recheck_warnings(One(Warning::ThrusterPropertiesTooLong(bank)));
+                            self.model.recheck_warnings(One(Warning::ThrusterPropertiesInvalidVersion(bank)));
                         }
                         UiState::reset_widget_color(ui);
                     } else {
@@ -1375,15 +1471,15 @@ impl PofToolsGui {
 
                 CollapsingHeader::new("Properties Raw").show(ui, |ui| {
                     if let Some(bank) = bank_num {
-                        if self.warnings.contains(&Warning::ThrusterPropertiesInvalidVersion(bank)) {
+                        if self.model.warnings.contains(&Warning::ThrusterPropertiesInvalidVersion(bank)) {
                             UiState::set_widget_color(ui, Color32::YELLOW);
                         }
                         if ui
                             .add(egui::TextEdit::multiline(&mut self.model.thruster_banks[bank].properties).desired_rows(1))
                             .changed()
                         {
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::ThrusterPropertiesTooLong(bank)));
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::ThrusterPropertiesInvalidVersion(bank)));
+                            self.model.recheck_warnings(One(Warning::ThrusterPropertiesTooLong(bank)));
+                            self.model.recheck_warnings(One(Warning::ThrusterPropertiesInvalidVersion(bank)));
                         }
                         UiState::reset_widget_color(ui);
                     } else {
@@ -1398,13 +1494,12 @@ impl PofToolsGui {
 
                 ui.add_space(10.0);
 
-                let (pos, norm, radius) =
-                    if let TreeSelection::Thrusters(ThrusterSelection::BankPoint(bank, point)) = self.ui_state.tree_view_selection {
-                        let ThrusterGlow { position, normal, radius } = &mut self.model.thruster_banks[bank as usize].glows[point];
-                        (Some(position), Some(normal), Some(radius))
-                    } else {
-                        (None, None, None)
-                    };
+                let (pos, norm, radius) = if let TreeValue::Thrusters(ThrusterTreeValue::BankPoint(bank, point)) = self.ui_state.tree_view_selection {
+                    let ThrusterGlow { position, normal, radius } = &mut self.model.thruster_banks[bank as usize].glows[point];
+                    (Some(position), Some(normal), Some(radius))
+                } else {
+                    (None, None, None)
+                };
 
                 ui.label("Radius:");
                 UiState::model_value_edit(&mut self.ui_state.viewport_3d_dirty, ui, false, radius, radius_string);
@@ -1415,47 +1510,48 @@ impl PofToolsGui {
 
                 if let Some(response) = bank_idx_response {
                     let new_idx = response.apply(&mut self.model.thruster_banks);
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All); //FIX
+                    self.model.recheck_warnings(All); //FIX
 
-                    self.ui_state.tree_view_selection = TreeSelection::Thrusters(ThrusterSelection::bank(new_idx));
-                    self.ui_state.tree_view_force_open = Some(TreeSelection::Thrusters(ThrusterSelection::bank(new_idx)));
+                    self.ui_state.tree_view_selection = TreeValue::Thrusters(ThrusterTreeValue::bank(new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::Thrusters(ThrusterTreeValue::bank(new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 } else if let Some(response) = point_idx_response {
                     let new_idx = response.apply(&mut self.model.thruster_banks[bank_num.unwrap()].glows);
 
-                    self.ui_state.tree_view_selection = TreeSelection::Thrusters(ThrusterSelection::bank_point(bank_num.unwrap(), new_idx));
+                    self.ui_state.tree_view_selection = TreeValue::Thrusters(ThrusterTreeValue::bank_point(bank_num.unwrap(), new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::Thrusters(ThrusterTreeValue::bank_point(bank_num.unwrap(), new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 }
             }
             PropertiesPanel::Weapon { position_string, normal_string, offset_string } => {
                 let (mut weapon_system, bank_num, point_num) = match self.ui_state.tree_view_selection {
-                    TreeSelection::Weapons(WeaponSelection::Header) => {
+                    TreeValue::Weapons(WeaponTreeValue::Header) => {
                         ui.heading("Weapons");
                         (None, None, None)
                     }
-                    TreeSelection::Weapons(WeaponSelection::PriHeader) => {
+                    TreeValue::Weapons(WeaponTreeValue::PriHeader) => {
                         ui.heading("Primary Weapons");
                         (Some((&mut self.model.primary_weps, true)), None, None)
                     }
-                    TreeSelection::Weapons(WeaponSelection::PriBank(bank)) => {
+                    TreeValue::Weapons(WeaponTreeValue::PriBank(bank)) => {
                         ui.heading("Primary Weapons");
                         (Some((&mut self.model.primary_weps, true)), Some(bank), None)
                     }
-                    TreeSelection::Weapons(WeaponSelection::PriBankPoint(bank, point)) => {
+                    TreeValue::Weapons(WeaponTreeValue::PriBankPoint(bank, point)) => {
                         ui.heading("Primary Weapons");
                         (Some((&mut self.model.primary_weps, true)), Some(bank), Some(point))
                     }
-                    TreeSelection::Weapons(WeaponSelection::SecHeader) => {
+                    TreeValue::Weapons(WeaponTreeValue::SecHeader) => {
                         ui.heading("Secondary Weapons");
                         (Some((&mut self.model.secondary_weps, false)), None, None)
                     }
-                    TreeSelection::Weapons(WeaponSelection::SecBank(bank)) => {
+                    TreeValue::Weapons(WeaponTreeValue::SecBank(bank)) => {
                         ui.heading("Secondary Weapons");
                         (Some((&mut self.model.secondary_weps, false)), Some(bank), None)
                     }
-                    TreeSelection::Weapons(WeaponSelection::SecBankPoint(bank, point)) => {
+                    TreeValue::Weapons(WeaponTreeValue::SecBankPoint(bank, point)) => {
                         ui.heading("Secondary Weapons");
                         (Some((&mut self.model.secondary_weps, false)), Some(bank), Some(point))
                     }
@@ -1463,7 +1559,7 @@ impl PofToolsGui {
                         unreachable!();
                     }
                 };
-                let weapon_selection = if let TreeSelection::Weapons(selection) = self.ui_state.tree_view_selection {
+                let weapon_selection = if let TreeValue::Weapons(selection) = self.ui_state.tree_view_selection {
                     selection
                 } else {
                     unreachable!()
@@ -1487,7 +1583,7 @@ impl PofToolsGui {
                 ui.add_space(10.0);
 
                 let (pos, norm, offset) =
-                    if let TreeSelection::Weapons(WeaponSelection::PriBankPoint(bank, point) | WeaponSelection::SecBankPoint(bank, point)) =
+                    if let TreeValue::Weapons(WeaponTreeValue::PriBankPoint(bank, point) | WeaponTreeValue::SecBankPoint(bank, point)) =
                         self.ui_state.tree_view_selection
                     {
                         let WeaponHardpoint { position, normal, offset } = &mut weapon_system.as_mut().unwrap().0[bank as usize][point];
@@ -1504,7 +1600,11 @@ impl PofToolsGui {
                 let offset_changed = UiState::model_value_edit(
                     &mut self.ui_state.viewport_3d_dirty,
                     ui,
-                    self.warnings.contains(&Warning::WeaponOffsetInvalidVersion(weapon_selection)),
+                    self.model.warnings.contains(&Warning::WeaponOffsetInvalidVersion {
+                        primary: weapon_selection.is_primary(),
+                        bank: bank_num.unwrap_or_default(),
+                        point: point_num.unwrap_or_default(),
+                    }),
                     offset,
                     offset_string,
                 )
@@ -1514,25 +1614,31 @@ impl PofToolsGui {
                     let (weapon_system, is_primary) = weapon_system.unwrap();
                     let new_idx = response.apply(weapon_system);
 
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All); // FIX
+                    self.model.recheck_warnings(All); // FIX
 
-                    self.ui_state.tree_view_selection = TreeSelection::Weapons(WeaponSelection::bank(is_primary, new_idx));
-                    self.ui_state.tree_view_force_open = Some(TreeSelection::Weapons(WeaponSelection::bank(is_primary, new_idx)));
+                    self.ui_state.tree_view_selection = TreeValue::Weapons(WeaponTreeValue::bank(is_primary, new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::Weapons(WeaponTreeValue::bank(is_primary, new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 } else if let Some(response) = point_idx_response {
                     let (weapon_system, is_primary) = weapon_system.unwrap();
                     let new_idx = response.apply(&mut weapon_system[bank_num.unwrap()]);
 
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All); // FIX
+                    self.model.recheck_warnings(All); // FIX
 
-                    self.ui_state.tree_view_selection = TreeSelection::Weapons(WeaponSelection::bank_point(is_primary, bank_num.unwrap(), new_idx));
+                    self.ui_state.tree_view_selection = TreeValue::Weapons(WeaponTreeValue::bank_point(is_primary, bank_num.unwrap(), new_idx));
+                    self.ui_state.tree_view_force_open =
+                        Some(TreeValue::Weapons(WeaponTreeValue::bank_point(is_primary, bank_num.unwrap(), new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 }
 
                 if offset_changed {
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::WeaponOffsetInvalidVersion(weapon_selection)));
+                    self.model.recheck_warnings(One(Warning::WeaponOffsetInvalidVersion {
+                        primary: weapon_selection.is_primary(),
+                        bank: bank_num.unwrap(),
+                        point: point_num.unwrap(),
+                    }));
                 }
             }
             PropertiesPanel::DockingBay {
@@ -1546,7 +1652,7 @@ impl PofToolsGui {
                 ui.separator();
 
                 let bay_num = match self.ui_state.tree_view_selection {
-                    TreeSelection::DockingBays(DockingSelection::Bay(bay)) => Some(bay),
+                    TreeValue::DockingBays(DockingTreeValue::Bay(bay)) => Some(bay),
                     _ => None,
                 };
 
@@ -1559,8 +1665,8 @@ impl PofToolsGui {
                     if let Some(bay) = bay_num {
                         if ui.text_edit_singleline(name_string).changed() {
                             pof::properties_update_field(&mut self.model.docking_bays[bay].properties, "$name", name_string);
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::DockingBayNameTooLong(bay)));
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::DockingBayPropertiesTooLong(bay)));
+                            self.model.recheck_warnings(One(Warning::DockingBayNameTooLong(bay)));
+                            self.model.recheck_warnings(One(Warning::DockingBayPropertiesTooLong(bay)));
                         }
                     } else {
                         ui.add_enabled(false, egui::TextEdit::singleline(&mut blank_string));
@@ -1587,7 +1693,7 @@ impl PofToolsGui {
                         "$parent_submodel",
                         &subobj_names_list[new_subobj],
                     );
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::DockingBayPropertiesTooLong(bay_num.unwrap())));
+                    self.model.recheck_warnings(One(Warning::DockingBayPropertiesTooLong(bay_num.unwrap())));
                     self.ui_state.viewport_3d_dirty = true;
                 }
 
@@ -1616,7 +1722,7 @@ impl PofToolsGui {
                         } else {
                             self.model.docking_bays[bay_num.unwrap()].path = Some(PathId(*path_num as u32))
                         }
-                        PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::DockingBayWithoutPath(bay_num.unwrap())));
+                        self.model.recheck_warnings(One(Warning::DockingBayWithoutPath(bay_num.unwrap())));
                     }
                 });
 
@@ -1631,8 +1737,8 @@ impl PofToolsGui {
                             if let Some(new_name) = pof::properties_get_field(&self.model.docking_bays[bay].properties, "$name") {
                                 *name_string = new_name.to_string();
                             }
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::DockingBayNameTooLong(bay)));
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::DockingBayPropertiesTooLong(bay)));
+                            self.model.recheck_warnings(One(Warning::DockingBayNameTooLong(bay)));
+                            self.model.recheck_warnings(One(Warning::DockingBayPropertiesTooLong(bay)));
                         }
                     } else {
                         ui.add_enabled(false, egui::TextEdit::multiline(&mut String::new()).desired_rows(1));
@@ -1689,9 +1795,10 @@ impl PofToolsGui {
                 if let Some(response) = bay_idx_response {
                     let new_idx = response.apply(&mut self.model.docking_bays);
 
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All); // FIX
+                    self.model.recheck_warnings(All); // FIX
 
-                    self.ui_state.tree_view_selection = TreeSelection::DockingBays(DockingSelection::bay(new_idx));
+                    self.ui_state.tree_view_selection = TreeValue::DockingBays(DockingTreeValue::bay(new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::DockingBays(DockingTreeValue::bay(new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 }
@@ -1712,8 +1819,8 @@ impl PofToolsGui {
                 ui.separator();
 
                 let (bank_num, point_num) = match self.ui_state.tree_view_selection {
-                    TreeSelection::Glows(GlowSelection::Bank(bank)) => (Some(bank), None),
-                    TreeSelection::Glows(GlowSelection::BankPoint(bank, point)) => (Some(bank), Some(point)),
+                    TreeValue::Glows(GlowTreeValue::Bank(bank)) => (Some(bank), None),
+                    TreeValue::Glows(GlowTreeValue::BankPoint(bank, point)) => (Some(bank), Some(point)),
                     _ => (None, None),
                 };
 
@@ -1727,7 +1834,7 @@ impl PofToolsGui {
                 if let Some(bank) = bank_num {
                     if ui.add(egui::TextEdit::singleline(glow_texture_string).desired_rows(1)).changed() {
                         pof::properties_update_field(&mut self.model.glow_banks[bank].properties, "$glow_texture", glow_texture_string);
-                        PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::GlowBankPropertiesTooLong(bank)));
+                        self.model.recheck_warnings(One(Warning::GlowBankPropertiesTooLong(bank)));
                     }
                 } else {
                     ui.add_enabled(false, egui::TextEdit::singleline(&mut blank_string).desired_rows(1));
@@ -1740,11 +1847,11 @@ impl PofToolsGui {
                 }
 
                 let (disp_time, on_time, off_time, lod, glow_type) =
-                    if let TreeSelection::Glows(GlowSelection::BankPoint(bank, _)) = self.ui_state.tree_view_selection {
+                    if let TreeValue::Glows(GlowTreeValue::BankPoint(bank, _)) = self.ui_state.tree_view_selection {
                         let GlowPointBank { disp_time, on_time, off_time, lod, glow_type, .. } = &mut self.model.glow_banks[bank as usize];
 
                         (Some(disp_time), Some(on_time), Some(off_time), Some(lod), Some(glow_type))
-                    } else if let TreeSelection::Glows(GlowSelection::Bank(bank)) = self.ui_state.tree_view_selection {
+                    } else if let TreeValue::Glows(GlowTreeValue::Bank(bank)) = self.ui_state.tree_view_selection {
                         let GlowPointBank { disp_time, on_time, off_time, lod, glow_type, .. } = &mut self.model.glow_banks[bank as usize];
 
                         (Some(disp_time), Some(on_time), Some(off_time), Some(lod), Some(glow_type))
@@ -1790,7 +1897,7 @@ impl PofToolsGui {
                             .add(egui::TextEdit::multiline(&mut self.model.glow_banks[bank].properties).desired_rows(1))
                             .changed()
                         {
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::GlowBankPropertiesTooLong(bank)));
+                            self.model.recheck_warnings(One(Warning::GlowBankPropertiesTooLong(bank)));
                         }
                     } else {
                         ui.add_enabled(false, egui::TextEdit::multiline(&mut String::new()).desired_rows(1));
@@ -1799,9 +1906,9 @@ impl PofToolsGui {
 
                 ui.separator();
 
-                let glow_points = if let TreeSelection::Glows(GlowSelection::BankPoint(bank, _)) = self.ui_state.tree_view_selection {
+                let glow_points = if let TreeValue::Glows(GlowTreeValue::BankPoint(bank, _)) = self.ui_state.tree_view_selection {
                     Some(&mut self.model.glow_banks[bank as usize].glow_points)
-                } else if let TreeSelection::Glows(GlowSelection::Bank(bank)) = self.ui_state.tree_view_selection {
+                } else if let TreeValue::Glows(GlowTreeValue::Bank(bank)) = self.ui_state.tree_view_selection {
                     Some(&mut self.model.glow_banks[bank as usize].glow_points)
                 } else {
                     None
@@ -1809,7 +1916,7 @@ impl PofToolsGui {
 
                 let point_idx_response = UiState::list_manipulator_widget(ui, point_num, glow_points.map(|list| list.len()), "Point");
 
-                let (pos, norm, radius) = if let TreeSelection::Glows(GlowSelection::BankPoint(bank, point)) = self.ui_state.tree_view_selection {
+                let (pos, norm, radius) = if let TreeValue::Glows(GlowTreeValue::BankPoint(bank, point)) = self.ui_state.tree_view_selection {
                     let GlowPoint { position, normal, radius } = &mut self.model.glow_banks[bank].glow_points[point];
 
                     (Some(position), Some(normal), Some(radius))
@@ -1829,16 +1936,17 @@ impl PofToolsGui {
                 if let Some(response) = bank_idx_response {
                     let new_idx = response.apply(&mut self.model.glow_banks);
 
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All); // FIX
-                    self.ui_state.tree_view_selection = TreeSelection::Glows(GlowSelection::bank(new_idx));
-                    self.ui_state.tree_view_force_open = Some(TreeSelection::Glows(GlowSelection::bank(new_idx)));
+                    self.model.recheck_warnings(All); // FIX
+                    self.ui_state.tree_view_selection = TreeValue::Glows(GlowTreeValue::bank(new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::Glows(GlowTreeValue::bank(new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 } else if let Some(response) = point_idx_response {
                     let new_idx = response.apply(&mut self.model.glow_banks[bank_num.unwrap()].glow_points);
 
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All); // FIX
-                    self.ui_state.tree_view_selection = TreeSelection::Glows(GlowSelection::bank_point(bank_num.unwrap(), new_idx));
+                    self.model.recheck_warnings(All); // FIX
+                    self.ui_state.tree_view_selection = TreeValue::Glows(GlowTreeValue::bank_point(bank_num.unwrap(), new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::Glows(GlowTreeValue::bank_point(bank_num.unwrap(), new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 }
@@ -1848,7 +1956,7 @@ impl PofToolsGui {
                 ui.separator();
 
                 let point_num = match self.ui_state.tree_view_selection {
-                    TreeSelection::SpecialPoints(SpecialPointSelection::Point(point)) => Some(point),
+                    TreeValue::SpecialPoints(SpecialPointTreeValue::Point(point)) => Some(point),
                     _ => None,
                 };
 
@@ -1860,7 +1968,7 @@ impl PofToolsGui {
                     ui.label("Name:");
                     if let Some(point) = point_num {
                         if ui.add(egui::TextEdit::singleline(&mut self.model.special_points[point].name)).changed() {
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::SpecialPointNameTooLong(point)));
+                            self.model.recheck_warnings(One(Warning::SpecialPointNameTooLong(point)));
                         }
                     } else {
                         ui.add_enabled(false, egui::TextEdit::singleline(name_string));
@@ -1890,7 +1998,7 @@ impl PofToolsGui {
                         });
                         if changed {
                             pof::properties_update_field(&mut self.model.special_points[point].properties, "$special", types[idx]);
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::SpecialPointPropertiesTooLong(point)));
+                            self.model.recheck_warnings(One(Warning::SpecialPointPropertiesTooLong(point)));
                         }
                     } else {
                         egui::ComboBox::from_label("Type").show_ui(ui, |ui| {
@@ -1908,7 +2016,7 @@ impl PofToolsGui {
                             if let Some(new_name) = pof::properties_get_field(&self.model.special_points[point].properties, "$name") {
                                 *name_string = new_name.to_string();
                             }
-                            PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::SpecialPointPropertiesTooLong(point)));
+                            self.model.recheck_warnings(One(Warning::SpecialPointPropertiesTooLong(point)));
                         }
                     } else {
                         ui.add_enabled(false, egui::TextEdit::multiline(&mut String::new()).desired_rows(1));
@@ -1919,7 +2027,7 @@ impl PofToolsGui {
 
                 ui.add_space(10.0);
 
-                let (pos, radius) = if let TreeSelection::SpecialPoints(SpecialPointSelection::Point(point)) = self.ui_state.tree_view_selection {
+                let (pos, radius) = if let TreeValue::SpecialPoints(SpecialPointTreeValue::Point(point)) = self.ui_state.tree_view_selection {
                     let SpecialPoint { position, radius, .. } = &mut self.model.special_points[point];
                     (Some(position), Some(radius))
                 } else {
@@ -1933,8 +2041,9 @@ impl PofToolsGui {
                 if let Some(response) = spec_point_idx_response {
                     let new_idx = response.apply(&mut self.model.special_points);
 
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All); // FIX
-                    self.ui_state.tree_view_selection = TreeSelection::SpecialPoints(SpecialPointSelection::point(new_idx));
+                    self.model.recheck_warnings(All); // FIX
+                    self.ui_state.tree_view_selection = TreeValue::SpecialPoints(SpecialPointTreeValue::point(new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::SpecialPoints(SpecialPointTreeValue::point(new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 }
@@ -1944,8 +2053,8 @@ impl PofToolsGui {
                 ui.separator();
 
                 let (turret_num, point_num) = match self.ui_state.tree_view_selection {
-                    TreeSelection::Turrets(TurretSelection::Turret(turret)) => (Some(turret), None),
-                    TreeSelection::Turrets(TurretSelection::TurretPoint(turret, point)) => (Some(turret), Some(point)),
+                    TreeValue::Turrets(TurretTreeValue::Turret(turret)) => (Some(turret), None),
+                    TreeValue::Turrets(TurretTreeValue::TurretPoint(turret, point)) => (Some(turret), Some(point)),
                     _ => (None, None),
                 };
 
@@ -1958,7 +2067,7 @@ impl PofToolsGui {
 
                 if let Some(new_subobj) = UiState::subobject_combo_box(ui, &subobj_names_list, base_idx, turret_num, "Base object", None) {
                     self.model.turrets[turret_num.unwrap()].base_obj = ObjectId(new_subobj as u32);
-                    PofToolsGui::recheck_errors(&mut self.errors, &self.model, One(Error::InvalidTurretGunSubobject(turret_num.unwrap())));
+                    self.model.recheck_errors(One(Error::InvalidTurretGunSubobject(turret_num.unwrap())));
                 }
 
                 // turret gun subobjexct combo box is a bit trickier since we only want to show valid subobjects (and the currently used one,
@@ -1974,7 +2083,7 @@ impl PofToolsGui {
                         .get_valid_gun_subobjects_for_turret(self.model.turrets[num].gun_obj, self.model.turrets[num].base_obj);
                     gun_subobj_ids_list = list;
                     gun_subobj_idx = idx;
-                    if self.errors.contains(&Error::InvalidTurretGunSubobject(num)) {
+                    if self.model.errors.contains(&Error::InvalidTurretGunSubobject(num)) {
                         for (i, &id) in gun_subobj_ids_list.iter().enumerate() {
                             if id == self.model.turrets[num].gun_obj {
                                 error_idx = Some(i);
@@ -1994,11 +2103,11 @@ impl PofToolsGui {
                 {
                     // the unwraps are ok here, if it were none, the combo box would be un-interactable
                     self.model.turrets[turret_num.unwrap()].gun_obj = gun_subobj_ids_list[new_idx];
-                    PofToolsGui::recheck_errors(&mut self.errors, &self.model, One(Error::InvalidTurretGunSubobject(turret_num.unwrap())));
+                    self.model.recheck_errors(One(Error::InvalidTurretGunSubobject(turret_num.unwrap())));
                     self.ui_state.viewport_3d_dirty = true;
                 }
 
-                let norm = if let TreeSelection::Turrets(TurretSelection::Turret(turret) | TurretSelection::TurretPoint(turret, _)) =
+                let norm = if let TreeValue::Turrets(TurretTreeValue::Turret(turret) | TurretTreeValue::TurretPoint(turret, _)) =
                     self.ui_state.tree_view_selection
                 {
                     Some(&mut self.model.turrets[turret].normal)
@@ -2018,7 +2127,7 @@ impl PofToolsGui {
 
                 ui.add_space(10.0);
 
-                let pos = if let TreeSelection::Turrets(TurretSelection::TurretPoint(turret, point)) = self.ui_state.tree_view_selection {
+                let pos = if let TreeValue::Turrets(TurretTreeValue::TurretPoint(turret, point)) = self.ui_state.tree_view_selection {
                     Some(&mut self.model.turrets[turret as usize].fire_points[point])
                 } else {
                     None
@@ -2030,15 +2139,17 @@ impl PofToolsGui {
                 if let Some(response) = turret_idx_response {
                     let new_idx = response.apply(&mut self.model.turrets);
 
-                    PofToolsGui::recheck_errors(&mut self.errors, &self.model, All); // FIX
-                    self.ui_state.tree_view_selection = TreeSelection::Turrets(TurretSelection::turret(new_idx));
+                    self.model.recheck_errors(All); // FIX
+                    self.ui_state.tree_view_selection = TreeValue::Turrets(TurretTreeValue::turret(new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::Turrets(TurretTreeValue::turret(new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 } else if let Some(response) = point_idx_response {
                     let new_idx = response.apply(&mut self.model.turrets[turret_num.unwrap()].fire_points);
 
-                    PofToolsGui::recheck_errors(&mut self.errors, &self.model, All); // FIX
-                    self.ui_state.tree_view_selection = TreeSelection::Turrets(TurretSelection::turret_point(turret_num.unwrap(), new_idx));
+                    self.model.recheck_errors(All); // FIX
+                    self.ui_state.tree_view_selection = TreeValue::Turrets(TurretTreeValue::turret_point(turret_num.unwrap(), new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::Turrets(TurretTreeValue::turret_point(turret_num.unwrap(), new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 }
@@ -2048,8 +2159,8 @@ impl PofToolsGui {
                 ui.separator();
 
                 let (path_num, point_num) = match self.ui_state.tree_view_selection {
-                    TreeSelection::Paths(PathSelection::Path(path)) => (Some(path), None),
-                    TreeSelection::Paths(PathSelection::PathPoint(path, point)) => (Some(path), Some(point)),
+                    TreeValue::Paths(PathTreeValue::Path(path)) => (Some(path), None),
+                    TreeValue::Paths(PathTreeValue::PathPoint(path, point)) => (Some(path), Some(point)),
                     _ => (None, None),
                 };
 
@@ -2063,8 +2174,8 @@ impl PofToolsGui {
                         .add(egui::TextEdit::multiline(&mut self.model.paths[num].name).desired_rows(1))
                         .changed()
                     {
-                        PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::DuplicatePathName(num)));
-                        PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, One(Warning::PathNameTooLong(num)));
+                        self.model.recheck_warnings(One(Warning::DuplicatePathName(num)));
+                        self.model.recheck_warnings(One(Warning::PathNameTooLong(num)));
                     };
                 } else {
                     ui.add_enabled(false, egui::TextEdit::multiline(name).desired_rows(1));
@@ -2085,7 +2196,7 @@ impl PofToolsGui {
 
                 ui.add_space(10.0);
 
-                let (radius, pos) = if let TreeSelection::Paths(PathSelection::PathPoint(path, point)) = self.ui_state.tree_view_selection {
+                let (radius, pos) = if let TreeValue::Paths(PathTreeValue::PathPoint(path, point)) = self.ui_state.tree_view_selection {
                     let PathPoint { position, radius, .. } = &mut self.model.paths[path as usize].points[point];
                     (Some(radius), Some(position))
                 } else {
@@ -2103,15 +2214,17 @@ impl PofToolsGui {
                     }
                     let new_idx = response.apply(&mut self.model.paths);
 
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All); // FIX
+                    self.model.recheck_warnings(All); // FIX
 
-                    self.ui_state.tree_view_selection = TreeSelection::Paths(PathSelection::path(new_idx));
+                    self.ui_state.tree_view_selection = TreeValue::Paths(PathTreeValue::path(new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::Paths(PathTreeValue::path(new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 } else if let Some(response) = point_idx_response {
                     let new_idx = response.apply(&mut self.model.paths[path_num.unwrap()].points);
 
-                    self.ui_state.tree_view_selection = TreeSelection::Paths(PathSelection::path_point(path_num.unwrap(), new_idx));
+                    self.ui_state.tree_view_selection = TreeValue::Paths(PathTreeValue::path_point(path_num.unwrap(), new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::Paths(PathTreeValue::path_point(path_num.unwrap(), new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 }
@@ -2132,7 +2245,7 @@ impl PofToolsGui {
 
                 ui.add_space(10.0);
 
-                let (lod, offset) = if let TreeSelection::Insignia(InsigniaSelection::Insignia(idx)) = self.ui_state.tree_view_selection {
+                let (lod, offset) = if let TreeValue::Insignia(InsigniaTreeValue::Insignia(idx)) = self.ui_state.tree_view_selection {
                     let Insignia { detail_level, offset, .. } = &mut self.model.insignias[idx];
                     (Some(detail_level), Some(offset))
                 } else {
@@ -2149,7 +2262,7 @@ impl PofToolsGui {
                 ui.separator();
 
                 let eye_num = match self.ui_state.tree_view_selection {
-                    TreeSelection::EyePoints(EyeSelection::EyePoint(point)) => Some(point),
+                    TreeValue::EyePoints(EyeTreeValue::EyePoint(point)) => Some(point),
                     _ => None,
                 };
 
@@ -2174,7 +2287,7 @@ impl PofToolsGui {
 
                 ui.add_space(10.0);
 
-                let (pos, norm) = if let TreeSelection::EyePoints(EyeSelection::EyePoint(point)) = self.ui_state.tree_view_selection {
+                let (pos, norm) = if let TreeValue::EyePoints(EyeTreeValue::EyePoint(point)) = self.ui_state.tree_view_selection {
                     let EyePoint { offset, normal, .. } = &mut self.model.eye_points[point];
                     (Some(offset), Some(normal))
                 } else {
@@ -2188,8 +2301,9 @@ impl PofToolsGui {
                 if let Some(response) = eye_idx_response {
                     let new_idx = response.apply(&mut self.model.eye_points);
 
-                    PofToolsGui::recheck_warnings(&mut self.warnings, &self.model, All); //FIX
-                    self.ui_state.tree_view_selection = TreeSelection::EyePoints(EyeSelection::point(new_idx));
+                    self.model.recheck_warnings(All); //FIX
+                    self.ui_state.tree_view_selection = TreeValue::EyePoints(EyeTreeValue::point(new_idx));
+                    self.ui_state.tree_view_force_open = Some(TreeValue::EyePoints(EyeTreeValue::point(new_idx)));
                     properties_panel_dirty = true;
                     self.ui_state.viewport_3d_dirty = true;
                 }

--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -1347,8 +1347,8 @@ impl PofToolsGui {
                                         }
                                     });
                                 }
-                                pof::NameLink::DetailLevel(_) => has_detail_level = true,
-                                pof::NameLink::DetailLevelOf(detail_parent_id) => {
+                                pof::NameLink::DetailLevel(..) => has_detail_level = true,
+                                pof::NameLink::DetailLevelOf(detail_parent_id, _) => {
                                     ui.horizontal_wrapped(|ui| {
                                         ui.label(RichText::new(format!("Is a detail object of: ")).weak().color(LIGHT_BLUE));
                                         if ui
@@ -1384,7 +1384,7 @@ impl PofToolsGui {
                         if has_detail_level {
                             ui.label(RichText::new(format!("Has detail level objects:")).weak().color(LIGHT_BLUE));
                             for link in &subobj.name_links {
-                                if let pof::NameLink::DetailLevel(id) = *link {
+                                if let pof::NameLink::DetailLevel(id, _) = *link {
                                     if ui
                                         .button(RichText::new(&self.model.sub_objects[id].name).weak().color(LIGHT_BLUE))
                                         .clicked()


### PR DESCRIPTION
Probably should have been broken into several PRs, but they have the common thread of 'coloring the tree values' so they came together. `TreeSelection` renamed to `TreeValue`, warnings/errors moved into pof crate, displayed warnings/errors are now links to their respective problem object, and destroyed/debris/detail objects are displayed in the subobject properties panel containing links to each other.