### PR TITLE
remove `parent out of order` assert

### DIFF
--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -159,7 +159,7 @@ impl<R: Read + Seek> Parser<R> {
                     let parent = if parent == u32::MAX {
                         None
                     } else {
-                        assert!(sub_objects[parent as usize].is_some(), "parent out of order");
+                        // assert!(sub_objects[parent as usize].is_some(), "parent out of order");
                         Some(ObjectId(parent))
                     };
 


### PR DESCRIPTION
We know PCS2 can make models like this, and Pof tools can run it no problem and will always fix it.