### PR TITLE
reset tree selection on model load

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -482,6 +482,7 @@ impl PofToolsGui {
         self.camera_offset = Vec3d::ZERO;
         self.camera_scale = self.model.header.max_radius * 1.5;
         self.ui_state.last_selected_subobj = self.model.header.detail_levels.first().copied();
+        self.ui_state.tree_view_selection = TreeValue::Header;
 
         self.load_textures();
 


### PR DESCRIPTION
Ensures `tree_val_selection` is always sanitary.