### PR TITLE
Filter out parsed -1 path nums on docking bays

### DIFF
--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -351,7 +351,7 @@ impl<R: Read + Seek> Parser<R> {
                     dock_points = Some(self.read_list(|this| {
                         let properties = this.read_string()?;
                         let paths = this.read_list(|this| this.read_u32())?; // spec allows for a list of paths but only the first will be used so dont bother
-                        let path = paths.first().map(|&x| PathId(x));
+                        let path = paths.first().filter(|x| **x < paths.len() as u32).map(|&x| PathId(x));
                         // same thing here, only first 2 are used
                         let mut dockpoints = this.read_list(|this| Ok(DockingPoint { position: this.read_vec3d()?, normal: this.read_vec3d()? }))?;
                         let mut iter = dockpoints.drain(..2);


### PR DESCRIPTION
PCS2 doesn't appear to inject a `-1` path num on a docking bay so it may be even older, not sure exactly what it means beyond a simple omission but it certainly isn't interpretable as a valid path.