### PR TITLE
guard against no subobject eye points

### DIFF
--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -602,7 +602,7 @@ mk_struct! {
 
     #[derive(Default, Debug, Clone)]
     pub struct EyePoint {
-        pub attached_subobj: ObjectId,
+        pub attached_subobj: Option<ObjectId>,
         pub position: Vec3d,
         pub normal: NormalVec3,
     }

--- a/pof/src/write.rs
+++ b/pof/src/write.rs
@@ -744,9 +744,11 @@ fn make_eyes_node<N: Node>(ctx: &mut N::Ctx, eye_points: &[EyePoint], up: UpAxis
         point_node.translate(pos.into());
         point_node.rotate(vec_to_rotation(&point.normal.0, up));
 
-        point_node
-            .children()
-            .push(N::from_name(format!("#e{}-parent", i), format!("#e{}-parent:{}", i, point.attached_subobj.0)).build(ctx));
+        if let Some(id) = point.attached_subobj {
+            point_node
+                .children()
+                .push(N::from_name(format!("#e{}-parent", i), format!("#e{}-parent:{}", i, id.0)).build(ctx));
+        }
 
         node.children().push(point_node.build(ctx));
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1625,7 +1625,15 @@ impl PofToolsGui {
                                 ui_state.tree_selectable_item(
                                     &self.model,
                                     ui,
-                                    &format!("{} {}", self.model.sub_objects[eye.attached_subobj].name, i + 1),
+                                    &format!(
+                                        "{} {}",
+                                        if let Some(id) = eye.attached_subobj {
+                                            &self.model.sub_objects[id].name
+                                        } else {
+                                            "(None)"
+                                        },
+                                        i + 1
+                                    ),
                                     TreeValue::EyePoints(EyeTreeValue::EyePoint(i)),
                                 );
                             }

--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -622,7 +622,7 @@ impl UiState {
                     self.properties_panel = PropertiesPanel::EyePoint {
                         position_string: format!("{}", model.eye_points[idx].position),
                         normal_string: format!("{}", model.eye_points[idx].normal.0),
-                        attached_subobj_idx: model.eye_points[idx].attached_subobj.0 as usize,
+                        attached_subobj_idx: model.eye_points[idx].attached_subobj.map_or(model.sub_objects.len(), |id| id.0 as usize),
                     }
                 }
                 _ => self.properties_panel = PropertiesPanel::default_eye(),
@@ -2573,10 +2573,17 @@ impl PofToolsGui {
 
                 ui.add_enabled_ui(eye_num.is_some(), |ui| {
                     if let Some(num) = eye_num {
-                        let name_list = self.model.get_subobj_names();
+                        let mut name_list = self.model.get_subobj_names();
+                        if self.model.eye_points[num].attached_subobj.is_none() {
+                            name_list.push("None".to_string());
+                        }
+
                         egui::ComboBox::from_label("Attached submodel")
-                            .show_index(ui, attached_subobj_idx, self.model.sub_objects.len(), |i| name_list[i].to_owned());
-                        self.model.eye_points[num].attached_subobj = ObjectId(*attached_subobj_idx as u32);
+                            .show_index(ui, attached_subobj_idx, name_list.len(), |i| name_list[i].to_owned());
+
+                        if *attached_subobj_idx < self.model.sub_objects.len() {
+                            self.model.eye_points[num].attached_subobj = Some(ObjectId(*attached_subobj_idx as u32));
+                        }
                     } else {
                         egui::ComboBox::from_label("Attached submodel").show_index(ui, attached_subobj_idx, 1, |_| format!(""));
                     }


### PR DESCRIPTION
`attached_subobj` is optional for eye points. Who knew!