### PR TITLE
Small fix to header translating transformations

### DIFF
--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -2365,12 +2365,12 @@ impl Model {
     pub fn apply_subobj_transform(&mut self, id: ObjectId, matrix: &TMat4<f32>, transform_offset: bool) {
         let zero = Vec3d::ZERO.into();
         let translation = matrix.transform_point(&zero) - zero;
-        let matrix = &matrix.append_translation(&(-translation));
+        let no_trans_matrix = &matrix.append_translation(&(-translation));
 
         let subobj = &mut self.sub_objects[id];
         subobj.radius = 0.0;
         for vert in &mut subobj.bsp_data.verts {
-            *vert = matrix * *vert;
+            *vert = no_trans_matrix * *vert;
             if !transform_offset {
                 *vert += translation.into();
             }
@@ -2380,7 +2380,7 @@ impl Model {
         }
 
         // this preserves rotations, but inverts scales, which is the proper transformation for normals
-        let norm_matrix = matrix.try_inverse().unwrap().transpose();
+        let norm_matrix = no_trans_matrix.try_inverse().unwrap().transpose();
 
         for norm in &mut subobj.bsp_data.norms {
             *norm = (&norm_matrix * *norm).normalize();
@@ -2398,7 +2398,7 @@ impl Model {
         let children = subobj.children.clone();
 
         for child_id in children {
-            self.apply_subobj_transform(child_id, matrix, true)
+            self.apply_subobj_transform(child_id, no_trans_matrix, true)
         }
     }
 

--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -1134,6 +1134,7 @@ impl PofToolsGui {
                     rebuild_all_buffers = true;
                     self.ui_state.viewport_3d_dirty = true;
                     self.ui_state.properties_panel_dirty = true;
+                    self.model.recheck_warnings(One(Warning::Detail0NonZeroOffset));
                 }
 
                 ui.add_space(10.0);


### PR DESCRIPTION
If `transform_offset` is true, the matrix, including translation should apply to the subobject (line 2395). This ensures a header transform with translates will actually move all the top level objects, rather than merely rotate or scale.