### PR TITLE
Fix accidental shadow with reading dock points

### DIFF
--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -387,8 +387,13 @@ impl<R: Read + Seek> Parser<R> {
                     assert!(dock_points.is_none());
                     dock_points = Some(self.read_list(|this| {
                         let properties = this.read_string()?;
-                        let paths = this.read_list(|this| this.read_u32())?; // spec allows for a list of paths but only the first will be used so dont bother
-                        let path = paths.first().filter(|x| **x < paths.len() as u32).map(|&x| PathId(x));
+                        let used_paths = this.read_list(|this| this.read_u32())?; // spec allows for a list of paths but only the first will be used so dont bother
+                        println!("dock paths {:?}, path len {:?}", used_paths, paths);
+                        let path = used_paths
+                            .first()
+                            .filter(|x| paths.as_ref().map_or(false, |paths| **x < paths.len() as u32))
+                            .map(|&x| PathId(x));
+                        println!("dock path {:?}", path);
                         // same thing here, only first 2 are used
                         let mut dockpoints = this.read_list(|this| Ok(DockingPoint { position: this.read_vec3d()?, normal: this.read_vec3d()? }))?;
                         let mut iter = dockpoints.drain(..2);


### PR DESCRIPTION
Checking validity of the path is to be done against the previously parsed list of actual paths, not the list of paths on this dockpoint, i.e. `paths` should not be referring to this local `paths`