### PR TITLE
Small fix for 'untextured' texture slot selection

### DIFF
--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -1682,7 +1682,11 @@ impl PofToolsGui {
                 }
 
                 ui.add_space(5.0);
-                if TreeValue::Textures(TextureTreeValue::tex(self.model.untextured_idx)) == self.ui_state.tree_view_selection {
+                if self
+                    .model
+                    .untextured_idx
+                    .map_or(false, |idx| TreeValue::Textures(TextureTreeValue::Texture(idx)) == self.ui_state.tree_view_selection)
+                {
                     ui.label("If this is intentional, you may prefer \"invisible\", which FSO will ignore.");
                 }
             }


### PR DESCRIPTION
This message should only appear if they've selected the 'Untextured' texture slot, but the `tex()` function will map `None`, no untextured slot, to the header tree value, erroneously displaying the message if the header is selected. Don't display if the untextured slot is None.