### PR TITLE
Fix errors not being rechecked on detail objects change

### DIFF
--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -1121,6 +1121,7 @@ impl PofToolsGui {
                     }
 
                     self.model.recheck_warnings(All);
+                    self.model.recheck_errors(All);
                     // FIX
                 }
 


### PR DESCRIPTION
Some errors relate to detail objects so recheck those too if detail objects change.