### PR TITLE
Two small fixes

### DIFF
--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -600,13 +600,6 @@ mk_struct! {
         pub kind: BspLightKind,
     }
 
-    #[derive(Default, Debug, Clone)]
-    pub struct EyePoint {
-        pub attached_subobj: Option<ObjectId>,
-        pub position: Vec3d,
-        pub normal: NormalVec3,
-    }
-
     #[derive(Debug, Clone, Default)]
     pub struct PathPoint {
         pub position: Vec3d,
@@ -614,12 +607,26 @@ mk_struct! {
         pub turrets: Vec<ObjectId>,
     }
 }
+
+#[derive(Default, Debug, Clone)]
+pub struct EyePoint {
+    pub attached_subobj: Option<ObjectId>,
+    pub position: Vec3d,
+    pub normal: NormalVec3,
+}
 impl EyePoint {
     pub fn apply_transform(&mut self, matrix: &TMat4<f32>) {
         self.position = matrix * self.position;
 
         let matrix = mat4_rotation_only(matrix);
         self.normal = (&matrix * self.normal.0).try_into().unwrap();
+    }
+}
+impl Serialize for EyePoint {
+    fn write_to(&self, w: &mut impl Write) -> io::Result<()> {
+        self.attached_subobj.map_or(u32::MAX, |id| id.0).write_to(w)?;
+        self.position.write_to(w)?;
+        self.normal.write_to(w)
     }
 }
 

--- a/pof/src/write.rs
+++ b/pof/src/write.rs
@@ -259,7 +259,7 @@ pub(crate) fn write_bsp_data(buf: &mut Vec<u8>, version: Version, bsp_data: &Bsp
                     let chunk_size_pointer = Fixup::new(buf, base)?;
 
                     poly.normal.write_to(buf)?;
-                    Vec3d::ZERO.write_to(buf)?; // center: unused
+                    verts[poly.verts[0].vertex_id.0 as usize].write_to(buf)?; // center: unused now, but old fso versions needed this to be on the plane at least
                     0f32.write_to(buf)?; // radius: unused
                     (poly.verts.len() as u32).write_to(buf)?;
                     poly.texture.write_to(buf)?;


### PR DESCRIPTION
1.  Make sure -1 is written for no subobj eye points, since the default serialize for options is to omit `None`.
2. Actually write a valid polygon "center" point for old pof versions. All it needs to be is on the plane, so any vert will do, but putting 0 *will* screw up these old pofs when used on old fso versions.