### PR TITLE
"SubObject" -> "Submodel"

### DIFF
--- a/pof/src/parse.rs
+++ b/pof/src/parse.rs
@@ -16,8 +16,8 @@ impl Model {
         // remove unused textures
         // tally up used texture ids
         let mut used_tex_ids = HashSet::new();
-        for subobj in &self.sub_objects {
-            for (_, poly) in subobj.bsp_data.collision_tree.leaves() {
+        for smodel in &self.submodels {
+            for (_, poly) in smodel.bsp_data.collision_tree.leaves() {
                 used_tex_ids.insert(poly.texture);
             }
         }
@@ -32,8 +32,8 @@ impl Model {
         }
 
         // apply the mapping
-        for subobj in self.sub_objects.iter_mut() {
-            for (_, poly) in subobj.bsp_data.collision_tree.leaves_mut() {
+        for smodel in self.submodels.iter_mut() {
+            for (_, poly) in smodel.bsp_data.collision_tree.leaves_mut() {
                 poly.texture = tex_map[&poly.texture];
             }
         }
@@ -58,7 +58,7 @@ impl<R: Read + Seek> Parser<R> {
     pub fn parse(&mut self, path: PathBuf) -> io::Result<Model> {
         // println!("parsing new model!");
         let mut header = None;
-        let mut sub_objects = vec![];
+        let mut submodels = vec![];
         let mut textures = None;
         let mut paths = None;
         let mut special_points = None;
@@ -75,7 +75,7 @@ impl<R: Read + Seek> Parser<R> {
         let mut shield_data = None;
 
         let mut shield_tree_chunk = None;
-        let mut debris_objs = vec![];
+        let mut debris_models = vec![];
 
         loop {
             let id = &match self.read_bytes() {
@@ -91,23 +91,23 @@ impl<R: Read + Seek> Parser<R> {
                     assert!(header.is_none());
                     assert_eq!(self.version >= Version::V21_16, id == b"HDR2");
 
-                    let (max_radius, obj_flags, num_subobjects);
+                    let (max_radius, obj_flags, num_submodels);
                     if self.version >= Version::V21_16 {
                         max_radius = self.read_f32()?;
                         obj_flags = self.read_u32()?;
-                        num_subobjects = self.read_u32()?;
+                        num_submodels = self.read_u32()?;
                     } else {
-                        num_subobjects = self.read_u32()?;
+                        num_submodels = self.read_u32()?;
                         max_radius = self.read_f32()?;
                         obj_flags = self.read_u32()?;
                     }
 
-                    sub_objects = vec![None; num_subobjects as usize];
+                    submodels = vec![None; num_submodels as usize];
 
                     let bounding_box = self.read_bbox()?;
 
-                    let detail_levels = self.read_list(|this| Ok(ObjectId(this.read_u32()?)))?;
-                    debris_objs = self.read_list(|this| Ok(ObjectId(this.read_u32()?)))?;
+                    let detail_levels = self.read_list(|this| Ok(SubmodelId(this.read_u32()?)))?;
+                    debris_models = self.read_list(|this| Ok(SubmodelId(this.read_u32()?)))?;
 
                     let (mut mass, center_of_mass, mut moment_of_inertia);
                     if self.version >= Version::V19_03 {
@@ -156,8 +156,8 @@ impl<R: Read + Seek> Parser<R> {
                         vec![]
                     };
 
-                    header = Some(ObjHeader {
-                        num_subobjects,
+                    header = Some(ModelHeader {
+                        num_submodels,
                         max_radius,
                         obj_flags,
                         bbox: bounding_box,
@@ -174,7 +174,7 @@ impl<R: Read + Seek> Parser<R> {
                     assert!(header.is_some());
                     assert_eq!(self.version >= Version::V21_16, id == b"OBJ2");
 
-                    let obj_id = ObjectId(self.read_u32()?); //id
+                    let model_id = SubmodelId(self.read_u32()?); //id
 
                     let (radius, parent, offset);
                     if self.version >= Version::V21_16 {
@@ -189,8 +189,8 @@ impl<R: Read + Seek> Parser<R> {
                     let parent = if parent == u32::MAX {
                         None
                     } else {
-                        // assert!(sub_objects[parent as usize].is_some(), "parent out of order");
-                        Some(ObjectId(parent))
+                        // assert!(submodels[parent as usize].is_some(), "parent out of order");
+                        Some(SubmodelId(parent))
                     };
 
                     let geo_center = self.read_vec3d()?;
@@ -217,11 +217,11 @@ impl<R: Read + Seek> Parser<R> {
                     assert!(self.read_i32()? == 0, "chunked models unimplemented in FSO");
                     let bsp_data_buffer = self.read_byte_buffer()?;
                     let bsp_data = parse_bsp_data(&bsp_data_buffer, self.version)?;
-                    //println!("parsed subobject {}", name);
+                    //println!("parsed submodel {}", name);
 
-                    assert!(sub_objects[obj_id.0 as usize].is_none());
-                    sub_objects[obj_id.0 as usize] = Some(SubObject {
-                        obj_id,
+                    assert!(submodels[model_id.0 as usize].is_none());
+                    submodels[model_id.0 as usize] = Some(Submodel {
+                        id: model_id,
                         radius,
                         parent,
                         offset,
@@ -234,10 +234,10 @@ impl<R: Read + Seek> Parser<R> {
                         translation_type,
                         translation_axis,
                         bsp_data,
-                        // these rest are to be filled later once we've parsed all the subobjects
+                        // these rest are to be filled later once we've parsed all the submodels
                         ..Default::default()
                     });
-                    //println!("parsed subobject {:#?}", sub_objects[obj_id.0 as usize]);
+                    //println!("parsed submodel {:#?}", submodels[model_id.0 as usize]);
                 }
                 b"TXTR" => {
                     assert!(textures.is_none());
@@ -260,7 +260,7 @@ impl<R: Read + Seek> Parser<R> {
                                 Ok(PathPoint {
                                     position: this.read_vec3d()?,
                                     radius: this.read_f32()?,
-                                    turrets: this.read_list(|this| Ok(ObjectId(this.read_u32()?)))?,
+                                    turrets: this.read_list(|this| Ok(SubmodelId(this.read_u32()?)))?,
                                 })
                             })?,
                         })
@@ -283,12 +283,12 @@ impl<R: Read + Seek> Parser<R> {
                 b"EYE " => {
                     eye_points = Some(self.read_list(|this| {
                         Ok(EyePoint {
-                            attached_subobj: {
+                            attached_submodel: {
                                 let id = this.read_u32()?;
                                 if id == u32::MAX {
                                     None
                                 } else {
-                                    Some(ObjectId(id))
+                                    Some(SubmodelId(id))
                                 }
                             },
                             position: this.read_vec3d()?,
@@ -318,13 +318,13 @@ impl<R: Read + Seek> Parser<R> {
                 }
                 b"TGUN" | b"TMIS" => {
                     turrets.extend(self.read_list(|this| {
-                        let base_obj = ObjectId(this.read_u32()?);
-                        let gun_obj = ObjectId(this.read_u32()?);
-                        assert!(sub_objects[base_obj.0 as usize].is_some(), "turret precedes base object");
-                        assert!(sub_objects[gun_obj.0 as usize].is_some(), "turret precedes gun object");
+                        let base_model = SubmodelId(this.read_u32()?);
+                        let gun_model = SubmodelId(this.read_u32()?);
+                        assert!(submodels[base_model.0 as usize].is_some(), "turret precedes base model");
+                        assert!(submodels[gun_model.0 as usize].is_some(), "turret precedes gun model");
                         Ok(Turret {
-                            base_obj,
-                            gun_obj,
+                            base_model,
+                            gun_model,
                             normal: this.read_vec3d()?.try_into().unwrap_or_default(),
                             fire_points: this.read_list(|this| this.read_vec3d())?,
                         })
@@ -361,7 +361,7 @@ impl<R: Read + Seek> Parser<R> {
                             disp_time: this.read_i32()?,
                             on_time: this.read_u32()?,
                             off_time: this.read_u32()?,
-                            obj_parent: ObjectId(this.read_u32()?),
+                            model_parent: SubmodelId(this.read_u32()?),
                             lod: this.read_u32()?,
                             glow_type: this.read_u32()?,
                             properties: {
@@ -476,25 +476,25 @@ impl<R: Read + Seek> Parser<R> {
             _ => None,
         };
 
-        // now that all the subobjects shouldve have been slotted in, assert that they all exist
-        let mut sub_objects = ObjVec(sub_objects.into_iter().map(|subobj_opt| subobj_opt.unwrap()).collect());
+        // now that all the submodels shouldve have been slotted in, assert that they all exist
+        let mut submodels = SubmodelVec(submodels.into_iter().map(|smodel_opt| smodel_opt.unwrap()).collect());
 
-        debris_objs.retain(|id| {
-            if id.0 < sub_objects.len() as u32 {
-                sub_objects[*id].is_debris_model = true;
+        debris_models.retain(|id| {
+            if id.0 < submodels.len() as u32 {
+                submodels[*id].is_debris_model = true;
                 true
             } else {
-                warn!("Invalid debris object {} discarded", id.0);
+                warn!("Invalid debris model {} discarded", id.0);
                 false
             }
         });
 
         let mut header = header.expect("No header chunk found???");
         header.detail_levels.retain(|id| {
-            if id.0 < sub_objects.len() as u32 {
+            if id.0 < submodels.len() as u32 {
                 true
             } else {
-                warn!("Invalid detail level object {} discarded", id.0);
+                warn!("Invalid detail level model {} discarded", id.0);
                 false
             }
         });
@@ -509,23 +509,23 @@ impl<R: Read + Seek> Parser<R> {
             }
         }
 
-        // sanitize eye point subobjs
+        // sanitize eye point submodels
         if let Some(points) = eye_points.as_deref_mut() {
             for (i, eye) in points.iter_mut().enumerate() {
-                if eye.attached_subobj.map_or(false, |id| id.0 >= sub_objects.len() as u32) {
-                    eye.attached_subobj = None;
+                if eye.attached_submodel.map_or(false, |id| id.0 >= submodels.len() as u32) {
+                    eye.attached_submodel = None;
                     warn!("Invalid eye point {} reset", i);
                 }
             }
         }
 
         let mut textures = textures.unwrap_or_default();
-        let untextured_idx = post_parse_fill_untextured_slot(&mut sub_objects, &mut textures);
+        let untextured_idx = post_parse_fill_untextured_slot(&mut submodels, &mut textures);
 
         let mut model = Model {
             version: self.version,
             header,
-            sub_objects,
+            submodels,
             textures,
             paths: paths.unwrap_or_default(),
             special_points: special_points.unwrap_or_default(),
@@ -934,14 +934,14 @@ fn mk_insignia(detail_level: Option<u32>, offset: Vec3d, vertices: Vec<Vec3d>, p
     }
 }
 
-fn push_subobj(
-    sub_objects: &mut Vec<SubObject>, offset: Vec3d, parent: Option<ObjectId>, name: &str, is_debris_model: bool, verts: Vec<Vec3d>,
+fn push_submodel(
+    submodels: &mut Vec<Submodel>, offset: Vec3d, parent: Option<SubmodelId>, name: &str, is_debris_model: bool, verts: Vec<Vec3d>,
     norms: Vec<Vec3d>, polygons: Vec<(TextureId, Vec<PolyVertex>)>,
-) -> ObjectId {
-    let obj_id = ObjectId(sub_objects.len() as _);
+) -> SubmodelId {
+    let model_id = SubmodelId(submodels.len() as _);
 
-    let mut new_subobj = SubObject {
-        obj_id,
+    let mut new_submodel = Submodel {
+        id: model_id,
         radius: Default::default(),
         parent,
         offset,
@@ -968,11 +968,11 @@ fn push_subobj(
         ..Default::default()
     };
 
-    new_subobj.bbox = new_subobj.recalc_bbox();
-    new_subobj.radius = new_subobj.recalc_radius();
+    new_submodel.bbox = new_submodel.recalc_bbox();
+    new_submodel.radius = new_submodel.recalc_radius();
 
-    sub_objects.push(new_subobj);
-    obj_id
+    submodels.push(new_submodel);
+    model_id
 }
 
 trait ParseCtx<'a> {
@@ -983,9 +983,11 @@ trait ParseCtx<'a> {
 
     fn parse_geometry(&self, node: &Self::Node, transform: &Mat4x4) -> (Vec<Vec3d>, Vec<Vec3d>, Vec<(TextureId, Vec<PolyVertex>)>);
 
-    fn parse_subobject_recursive(&self, model: &mut Model, node: Self::Node, parent: ObjectId, detail_level: Option<u32>, parent_transform: &Mat4x4) {
+    fn parse_submodel_recursive(
+        &self, model: &mut Model, node: Self::Node, parent: SubmodelId, detail_level: Option<u32>, parent_transform: &Mat4x4,
+    ) {
         let name = match node.name() {
-            None => return, // subobjects must have names!
+            None => return, // submodels must have names!
             Some(name) => name,
         };
         let mut transform = parent_transform * node.transform();
@@ -997,9 +999,9 @@ trait ParseCtx<'a> {
 
         let (vertices_out, normals_out, polygons_out) = self.parse_geometry(&node, &transform);
 
-        // ignore subobjects with no geo
+        // ignore submodels with no geo
         // metadata (empties with names like #properties) are handled below directly
-        // this function must *start* with a proper subobject
+        // this function must *start* with a proper submodel
         if polygons_out.is_empty() {
             return;
         }
@@ -1012,19 +1014,19 @@ trait ParseCtx<'a> {
                 return;
             }
 
-            let obj_id = push_subobj(&mut model.sub_objects, offset, Some(parent), name, false, vertices_out, normals_out, polygons_out);
+            let model_id = push_submodel(&mut model.submodels, offset, Some(parent), name, false, vertices_out, normals_out, polygons_out);
 
             for node in node.children() {
-                // make a pointer to the subobj we just pushed
-                // annoying, but the node children could be properties that modify it, or proper subobject children
-                // which will require that this subobject be already pushed into the list
-                let len = model.sub_objects.len() - 1;
-                let subobj = &mut model.sub_objects.0[len];
+                // make a pointer to the submodel we just pushed
+                // annoying, but the node children could be properties that modify it, or proper submodel children
+                // which will require that this submodel be already pushed into the list
+                let len = model.submodels.len() - 1;
+                let smodel = &mut model.submodels.0[len];
 
                 if let Some(name) = node.name() {
                     if name.starts_with('#') && name.contains("point") {
                         let turret = {
-                            match model.turrets.iter().position(|turret| turret.gun_obj == obj_id) {
+                            match model.turrets.iter().position(|turret| turret.gun_model == model_id) {
                                 Some(idx) => &mut model.turrets[idx],
                                 None => {
                                     model.turrets.push(Turret::default());
@@ -1034,48 +1036,48 @@ trait ParseCtx<'a> {
                             }
                         };
 
-                        turret.gun_obj = obj_id;
-                        turret.base_obj = if name.contains("gun") { parent } else { obj_id };
+                        turret.gun_model = model_id;
+                        turret.base_model = if name.contains("gun") { parent } else { model_id };
 
                         let (pos, norm, _) = node.parse_point(&transform, up);
                         turret.fire_points.push(pos);
                         turret.normal = norm.try_into().unwrap_or_default();
                         continue;
                     } else if name.starts_with('#') && name.contains("properties") {
-                        node.parse_properties(&mut subobj.properties);
+                        node.parse_properties(&mut smodel.properties);
                         continue;
                     } else if name.starts_with('#') && name.contains("mov-type") {
                         if let Some(idx) = name.find(':') {
                             if let Ok(val) = name[(idx + 1)..].parse::<i32>() {
-                                subobj.rotation_type = val.try_into().unwrap_or_default();
+                                smodel.rotation_type = val.try_into().unwrap_or_default();
                             }
                         }
                         continue;
                     } else if name.starts_with('#') && name.contains("mov-axis") {
                         if let Some(idx) = name.find(':') {
                             if let Ok(val) = name[(idx + 1)..].parse::<i32>() {
-                                subobj.rotation_axis = val.try_into().unwrap_or_default();
+                                smodel.rotation_axis = val.try_into().unwrap_or_default();
                             }
                         }
                         continue;
                     } else if name.starts_with('#') && name.contains("trans-type") {
                         if let Some(idx) = name.find(':') {
                             if let Ok(val) = name[(idx + 1)..].parse::<i32>() {
-                                subobj.translation_type = val.try_into().unwrap_or_default();
+                                smodel.translation_type = val.try_into().unwrap_or_default();
                             }
                         }
                         continue;
                     } else if name.starts_with('#') && name.contains("trans-axis") {
                         if let Some(idx) = name.find(':') {
                             if let Ok(val) = name[(idx + 1)..].parse::<i32>() {
-                                subobj.translation_axis = val.try_into().unwrap_or_default();
+                                smodel.translation_axis = val.try_into().unwrap_or_default();
                             }
                         }
                         continue;
                     }
                 }
 
-                self.parse_subobject_recursive(model, node, obj_id, detail_level, &transform);
+                self.parse_submodel_recursive(model, node, model_id, detail_level, &transform);
             }
         }
     }
@@ -1142,30 +1144,30 @@ trait ParseCtx<'a> {
                 } else if name.to_lowercase().contains("insig") {
                     model.insignias.push(mk_insignia(None, offset, vertices_out, polygons_out));
                 } else {
-                    // must be a subobject
+                    // must be a submodel
 
                     // this should probably be warned about...
                     if vertices_out.is_empty() || normals_out.is_empty() {
                         continue;
                     }
 
-                    let obj_id =
-                        push_subobj(&mut model.sub_objects, offset, None, name, name.starts_with("debris"), vertices_out, normals_out, polygons_out);
+                    let model_id =
+                        push_submodel(&mut model.submodels, offset, None, name, name.starts_with("debris"), vertices_out, normals_out, polygons_out);
 
                     let mut detail_level: Option<u32> = None;
                     if let Some(idx) = name.to_lowercase().find("detail") {
                         if let Ok(level) = name[(idx + 6)..].parse::<usize>() {
                             if level >= model.header.detail_levels.len() {
-                                model.header.detail_levels.resize(level + 1, obj_id);
+                                model.header.detail_levels.resize(level + 1, model_id);
                             } else {
-                                model.header.detail_levels[level] = obj_id;
+                                model.header.detail_levels[level] = model_id;
                             }
                             detail_level = Some(level as u32);
                         }
                     }
 
                     for node in node.children() {
-                        self.parse_subobject_recursive(model, node, obj_id, detail_level, &transform);
+                        self.parse_submodel_recursive(model, node, model_id, detail_level, &transform);
                     }
                 }
             } else if name == "#thrusters" {
@@ -1291,7 +1293,7 @@ trait ParseCtx<'a> {
                         } else if name.contains("parent") {
                             if let Some(idx) = name.find(":") {
                                 if let Ok(val) = &name[(idx + 1)..].parse() {
-                                    new_bank.obj_parent = ObjectId(*val);
+                                    new_bank.model_parent = SubmodelId(*val);
                                 }
                             }
                         } else if name.contains("ontime") {
@@ -1357,7 +1359,7 @@ trait ParseCtx<'a> {
                     for (_, name) in node_children_with_keyword(node, "parent") {
                         if let Some(idx) = name.find(":") {
                             if let Ok(val) = &name[(idx + 1)..].parse() {
-                                new_point.attached_subobj = Some(ObjectId(*val));
+                                new_point.attached_submodel = Some(SubmodelId(*val));
                                 break;
                             }
                         }
@@ -1371,21 +1373,21 @@ trait ParseCtx<'a> {
             }
         }
 
-        for i in 0..model.sub_objects.len() {
-            if let Some(parent) = model.sub_objects[ObjectId(i as u32)].parent {
-                let id = model.sub_objects[ObjectId(i as u32)].obj_id;
-                model.sub_objects[parent].children.push(id);
+        for i in 0..model.submodels.len() {
+            if let Some(parent) = model.submodels[SubmodelId(i as u32)].parent {
+                let id = model.submodels[SubmodelId(i as u32)].id;
+                model.submodels[parent].children.push(id);
             }
         }
 
-        if model.header.detail_levels.is_empty() && !model.sub_objects.is_empty() {
-            model.header.detail_levels.push(ObjectId(0));
+        if model.header.detail_levels.is_empty() && !model.submodels.is_empty() {
+            model.header.detail_levels.push(SubmodelId(0));
             // this is pretty bad, but not having any detail levels is worse
         }
 
-        model.header.num_subobjects = model.sub_objects.len() as _;
+        model.header.num_submodels = model.submodels.len() as _;
 
-        model.untextured_idx = post_parse_fill_untextured_slot(&mut model.sub_objects, &mut model.textures);
+        model.untextured_idx = post_parse_fill_untextured_slot(&mut model.submodels, &mut model.textures);
 
         model.header.max_radius = model.recalc_radius();
         model.header.bbox = model.recalc_bbox();

--- a/pof/src/types.rs
+++ b/pof/src/types.rs
@@ -35,7 +35,7 @@ macro_rules! id_type {
     };
 }
 
-id_type! {ObjectId, u32}
+id_type! {SubmodelId, u32}
 id_type! {TextureId, u32}
 id_type! {VertexId, u32}
 id_type! {NormalId, u32}
@@ -60,20 +60,20 @@ pub(crate) fn get_version() -> Version {
 
 // like a regular vector, but indexed with ObjectIds only, for some safety
 #[derive(Debug)]
-pub struct ObjVec<T>(pub Vec<T>);
-impl<T> Index<ObjectId> for ObjVec<T> {
+pub struct SubmodelVec<T>(pub Vec<T>);
+impl<T> Index<SubmodelId> for SubmodelVec<T> {
     type Output = T;
 
-    fn index(&self, index: ObjectId) -> &Self::Output {
+    fn index(&self, index: SubmodelId) -> &Self::Output {
         &self.0[index.0 as usize]
     }
 }
-impl<T> IndexMut<ObjectId> for ObjVec<T> {
-    fn index_mut(&mut self, index: ObjectId) -> &mut Self::Output {
+impl<T> IndexMut<SubmodelId> for SubmodelVec<T> {
+    fn index_mut(&mut self, index: SubmodelId) -> &mut Self::Output {
         &mut self.0[index.0 as usize]
     }
 }
-impl<'a, T> IntoIterator for &'a ObjVec<T> {
+impl<'a, T> IntoIterator for &'a SubmodelVec<T> {
     type Item = &'a T;
 
     type IntoIter = std::slice::Iter<'a, T>;
@@ -82,24 +82,24 @@ impl<'a, T> IntoIterator for &'a ObjVec<T> {
         self.iter()
     }
 }
-impl<T> Default for ObjVec<T> {
+impl<T> Default for SubmodelVec<T> {
     fn default() -> Self {
         Self(Default::default())
     }
 }
-impl<T> ObjVec<T> {
+impl<T> SubmodelVec<T> {
     fn iter(&self) -> std::slice::Iter<'_, T> {
         self.0.iter()
     }
 }
-impl<T> Deref for ObjVec<T> {
+impl<T> Deref for SubmodelVec<T> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
-impl<T> DerefMut for ObjVec<T> {
+impl<T> DerefMut for SubmodelVec<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -609,13 +609,13 @@ mk_struct! {
     pub struct PathPoint {
         pub position: Vec3d,
         pub radius: f32,
-        pub turrets: Vec<ObjectId>,
+        pub turrets: Vec<SubmodelId>,
     }
 }
 
 #[derive(Default, Debug, Clone)]
 pub struct EyePoint {
-    pub attached_subobj: Option<ObjectId>,
+    pub attached_submodel: Option<SubmodelId>,
     pub position: Vec3d,
     pub normal: NormalVec3,
 }
@@ -629,7 +629,7 @@ impl EyePoint {
 }
 impl Serialize for EyePoint {
     fn write_to(&self, w: &mut impl Write) -> io::Result<()> {
-        self.attached_subobj.map_or(u32::MAX, |id| id.0).write_to(w)?;
+        self.attached_submodel.map_or(u32::MAX, |id| id.0).write_to(w)?;
         self.position.write_to(w)?;
         self.normal.write_to(w)
     }
@@ -902,12 +902,12 @@ impl GlowPoint {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct ObjHeader {
+pub struct ModelHeader {
     pub max_radius: f32,
     pub obj_flags: u32,
-    pub num_subobjects: u32,
+    pub num_submodels: u32,
     pub bbox: BoundingBox,
-    pub detail_levels: Vec<ObjectId>,
+    pub detail_levels: Vec<SubmodelId>,
     pub mass: f32,
     pub center_of_mass: Vec3d,
     pub moment_of_inertia: Mat3d,
@@ -1394,32 +1394,32 @@ impl Default for SubsysRotationAxis {
     }
 }
 
-pub const MAX_DEBRIS_OBJECTS: u32 = 32;
+pub const MAX_DEBRIS_MODELS: u32 = 32;
 
 /// "semantic name links", fields derived specifically from their names
 /// recalculated by recalc_semantic_name_links
 #[derive(Debug, Copy, Clone)]
 pub enum NameLink {
     /// points from a turret to its destroyed version
-    DestroyedVersion(ObjectId),
+    DestroyedVersion(SubmodelId),
     /// back-link for [`DestroyedVersion`]
-    DestroyedVersionOf(ObjectId),
+    DestroyedVersionOf(SubmodelId),
     /// points to the debris version of this object
-    LiveDebris(ObjectId),
+    LiveDebris(SubmodelId),
     /// back-link for [`LiveDebris`]
-    LiveDebrisOf(ObjectId),
+    LiveDebrisOf(SubmodelId),
     /// Points from the highest detail level object to one of the lower detail levels.
     /// Repeats for each lower detail version; they are in arbitrary order
-    DetailLevel(ObjectId, u8),
+    DetailLevel(SubmodelId, u8),
     /// back-link for [`DetailLevel`]: points from lower detail to highest detail version
-    DetailLevelOf(ObjectId, u8),
+    DetailLevelOf(SubmodelId, u8),
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct SubObject {
-    pub obj_id: ObjectId,
+pub struct Submodel {
+    pub id: SubmodelId,
     pub radius: f32,
-    pub parent: Option<ObjectId>,
+    pub parent: Option<SubmodelId>,
     pub offset: Vec3d,
     pub geo_center: Vec3d,
     pub bbox: BoundingBox,
@@ -1432,19 +1432,19 @@ pub struct SubObject {
     pub bsp_data: BspData,
 
     // the following fields are derived information
-    pub children: Vec<ObjectId>,
+    pub children: Vec<SubmodelId>,
     pub is_debris_model: bool,
 
     // "semantic name links", fields derived specifically from their names
     // recalculated by recalc_semantic_name_links
     pub name_links: Vec<NameLink>,
 }
-impl SubObject {
-    pub fn parent(&self) -> Option<ObjectId> {
+impl Submodel {
+    pub fn parent(&self) -> Option<SubmodelId> {
         self.parent
     }
 
-    pub fn children(&self) -> std::slice::Iter<'_, ObjectId> {
+    pub fn children(&self) -> std::slice::Iter<'_, SubmodelId> {
         self.children.iter()
     }
 
@@ -1503,7 +1503,7 @@ impl SubObject {
         properties_get_field(&self.properties, "$special") == Some("subsystem")
     }
 
-    /// returns the surface area of the subobject, and the average surface area position
+    /// returns the surface area of the submodel, and the average surface area position
     pub fn surface_area_average_pos(&self) -> (f32, Vec3d) {
         let mut surface_area = 0.0;
         let mut weighted_sum = Vec3d::ZERO;
@@ -1528,16 +1528,16 @@ fn parse_uvec_fvec(props: &str) -> Option<(Vec3d, Vec3d)> {
     Some((uvec, fvec))
 }
 
-impl Serialize for SubObject {
+impl Serialize for Submodel {
     fn write_to(&self, w: &mut impl Write) -> io::Result<()> {
         let version = get_version();
-        self.obj_id.write_to(w)?;
+        self.id.write_to(w)?;
         if version >= Version::V21_16 {
             self.radius.write_to(w)?;
-            self.parent.unwrap_or(ObjectId(u32::MAX)).write_to(w)?;
+            self.parent.unwrap_or(SubmodelId(u32::MAX)).write_to(w)?;
             self.offset.write_to(w)?;
         } else {
-            self.parent.unwrap_or(ObjectId(u32::MAX)).write_to(w)?;
+            self.parent.unwrap_or(SubmodelId(u32::MAX)).write_to(w)?;
             self.offset.write_to(w)?;
             self.radius.write_to(w)?;
         }
@@ -1629,7 +1629,7 @@ impl Dock {
         properties_get_field(&self.properties, "$name")
     }
 
-    pub fn get_parent_obj(&self) -> Option<&str> {
+    pub fn get_parent_smodel(&self) -> Option<&str> {
         properties_get_field(&self.properties, "$parent_submodel")
     }
 
@@ -1647,8 +1647,8 @@ pub const MAX_TURRET_POINTS: usize = 10;
 mk_struct! {
     #[derive(Clone)]
     pub struct Turret {
-        pub base_obj: ObjectId,
-        pub gun_obj: ObjectId,
+        pub base_model: SubmodelId,
+        pub gun_model: SubmodelId,
         pub normal: NormalVec3,
         pub fire_points: Vec<Vec3d>,
     }
@@ -1657,8 +1657,8 @@ mk_struct! {
 impl Default for Turret {
     fn default() -> Self {
         Self {
-            base_obj: Default::default(),
-            gun_obj: Default::default(),
+            base_model: Default::default(),
+            gun_model: Default::default(),
             normal: Default::default(),
             fire_points: vec![],
         }
@@ -1668,8 +1668,8 @@ impl Default for Turret {
 impl Debug for Turret {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Turret")
-            .field("base_obj", &self.base_obj)
-            .field("gun_obj", &self.gun_obj)
+            .field("base_obj", &self.base_model)
+            .field("gun_obj", &self.gun_model)
             .field("normal", &self.normal)
             .field("fire_points", &self.fire_points.len())
             .finish()
@@ -1724,7 +1724,7 @@ pub struct GlowPointBank {
     pub disp_time: i32,
     pub on_time: u32,
     pub off_time: u32,
-    pub obj_parent: ObjectId,
+    pub model_parent: SubmodelId,
     pub lod: u32,
     pub glow_type: u32,
     pub properties: String,
@@ -1735,7 +1735,7 @@ impl Serialize for GlowPointBank {
         self.disp_time.write_to(w)?;
         self.on_time.write_to(w)?;
         self.off_time.write_to(w)?;
-        self.obj_parent.write_to(w)?;
+        self.model_parent.write_to(w)?;
         self.lod.write_to(w)?;
         self.glow_type.write_to(w)?;
         (self.glow_points.len() as u32).write_to(w)?;
@@ -1823,7 +1823,7 @@ mk_versions! {
     V22_00(2200, "22.00"),
     /// External weapon angle offset compatible
     V22_01(2201, "22.01"),
-    /// Extended vertex and normal limits per subobject and file size optimizations
+    /// Extended vertex and normal limits per submodel and file size optimizations
     V23_00(2300, "23.00"),
     /// Added submodel translation support
     V23_01(2301, "23.01"),
@@ -1832,8 +1832,8 @@ mk_versions! {
 #[derive(Debug, Default)]
 pub struct Model {
     pub version: Version,
-    pub header: ObjHeader,
-    pub sub_objects: ObjVec<SubObject>,
+    pub header: ModelHeader,
+    pub submodels: SubmodelVec<Submodel>,
     pub textures: Vec<String>,
     pub paths: Vec<Path>,
     pub special_points: Vec<SpecialPoint>,
@@ -1859,14 +1859,14 @@ impl Model {
     pub fn recheck_errors(&mut self, error_to_check: Set<Error>) {
         if let Set::One(error) = error_to_check {
             let failed_check = match &error {
-                Error::InvalidTurretGunSubobject(turret) => self.turret_gun_subobj_not_valid(*turret),
-                Error::TooManyDebrisObjects => self.num_debris_objects() > MAX_DEBRIS_OBJECTS,
-                Error::DetailAndDebrisObj(id) => self.header.detail_levels.contains(&id) && self.sub_objects[*id].is_debris_model,
-                Error::DetailObjWithParent(id) => self.header.detail_levels.contains(&id) && self.sub_objects[*id].parent().is_some(),
-                Error::TooManyVerts(id) => self.sub_objects[*id].bsp_data.verts.len() > self.max_verts_norms_per_subobj(),
-                Error::TooManyNorms(id) => self.sub_objects[*id].bsp_data.norms.len() > self.max_verts_norms_per_subobj(),
-                Error::DuplicateSubobjectName(name) => self.sub_objects.iter().filter(|subobj| subobj.name == *name).count() > 1,
-                Error::UnnamedSubObject(id) => self.sub_objects[*id].name.is_empty(),
+                Error::InvalidTurretGunSubmodel(turret) => self.turret_gun_submodel_not_valid(*turret),
+                Error::TooManyDebrisModels => self.num_debris_models() > MAX_DEBRIS_MODELS,
+                Error::DetailAndDebrisModel(id) => self.header.detail_levels.contains(&id) && self.submodels[*id].is_debris_model,
+                Error::DetailModelWithParent(id) => self.header.detail_levels.contains(&id) && self.submodels[*id].parent().is_some(),
+                Error::TooManyVerts(id) => self.submodels[*id].bsp_data.verts.len() > self.max_verts_norms_per_submodel(),
+                Error::TooManyNorms(id) => self.submodels[*id].bsp_data.norms.len() > self.max_verts_norms_per_submodel(),
+                Error::DuplicateSubmodelName(name) => self.submodels.iter().filter(|smodel| smodel.name == *name).count() > 1,
+                Error::UnnamedSubmodel(id) => self.submodels[*id].name.is_empty(),
             };
 
             let existing_warning = self.errors.contains(&error);
@@ -1879,53 +1879,53 @@ impl Model {
             self.errors.clear();
 
             for i in 0..self.turrets.len() {
-                if self.turret_gun_subobj_not_valid(i) {
-                    self.errors.insert(Error::InvalidTurretGunSubobject(i));
+                if self.turret_gun_submodel_not_valid(i) {
+                    self.errors.insert(Error::InvalidTurretGunSubmodel(i));
                 }
             }
 
-            if self.num_debris_objects() > MAX_DEBRIS_OBJECTS {
-                self.errors.insert(Error::TooManyDebrisObjects);
+            if self.num_debris_models() > MAX_DEBRIS_MODELS {
+                self.errors.insert(Error::TooManyDebrisModels);
             }
 
             for &id in &self.header.detail_levels {
-                let subobj = &self.sub_objects[id];
-                if subobj.parent().is_some() {
-                    self.errors.insert(Error::DetailObjWithParent(id));
+                let smodel = &self.submodels[id];
+                if smodel.parent().is_some() {
+                    self.errors.insert(Error::DetailModelWithParent(id));
                 }
-                if subobj.is_debris_model {
-                    self.errors.insert(Error::DetailAndDebrisObj(id));
-                }
-            }
-
-            for subobj in &self.sub_objects {
-                if subobj.name.is_empty() {
-                    self.errors.insert(Error::UnnamedSubObject(subobj.obj_id));
-                }
-
-                if subobj.bsp_data.verts.len() > self.max_verts_norms_per_subobj() {
-                    self.errors.insert(Error::TooManyVerts(subobj.obj_id));
-                }
-
-                if subobj.bsp_data.norms.len() > self.max_verts_norms_per_subobj() {
-                    self.errors.insert(Error::TooManyNorms(subobj.obj_id));
+                if smodel.is_debris_model {
+                    self.errors.insert(Error::DetailAndDebrisModel(id));
                 }
             }
 
-            for duped_name in self.sub_objects.iter().map(|subobj| &subobj.name).duplicates() {
-                self.errors.insert(Error::DuplicateSubobjectName(duped_name.clone()));
+            for smodel in &self.submodels {
+                if smodel.name.is_empty() {
+                    self.errors.insert(Error::UnnamedSubmodel(smodel.id));
+                }
+
+                if smodel.bsp_data.verts.len() > self.max_verts_norms_per_submodel() {
+                    self.errors.insert(Error::TooManyVerts(smodel.id));
+                }
+
+                if smodel.bsp_data.norms.len() > self.max_verts_norms_per_submodel() {
+                    self.errors.insert(Error::TooManyNorms(smodel.id));
+                }
+            }
+
+            for duped_name in self.submodels.iter().map(|smodel| &smodel.name).duplicates() {
+                self.errors.insert(Error::DuplicateSubmodelName(duped_name.clone()));
             }
         }
     }
 
-    fn turret_gun_subobj_not_valid(&self, turret_num: usize) -> bool {
+    fn turret_gun_submodel_not_valid(&self, turret_num: usize) -> bool {
         let turret = &self.turrets[turret_num];
-        if turret.base_obj == turret.gun_obj {
+        if turret.base_model == turret.gun_model {
             return false;
         }
 
-        for &child_id in self.sub_objects[turret.base_obj].children() {
-            if child_id == turret.gun_obj {
+        for &child_id in self.submodels[turret.base_model].children() {
+            if child_id == turret.gun_model {
                 return false;
             }
         }
@@ -1937,8 +1937,8 @@ impl Model {
     pub fn recheck_warnings(&mut self, warning_to_check: Set<Warning>) {
         if let Set::One(warning) = warning_to_check {
             let failed_check = match &warning {
-                Warning::RadiusTooSmall(subobj_opt) => self.radius_test_failed(*subobj_opt),
-                Warning::BBoxTooSmall(subobj_opt) => self.bbox_test_failed(*subobj_opt),
+                Warning::RadiusTooSmall(smodel_opt) => self.radius_test_failed(*smodel_opt),
+                Warning::BBoxTooSmall(smodel_opt) => self.bbox_test_failed(*smodel_opt),
                 Warning::DockingBayWithoutPath(bay_num) => self.docking_bays.get(*bay_num).map_or(false, |bay| bay.path.is_none()),
                 Warning::ThrusterPropertiesInvalidVersion(bank_idx) => {
                     self.version <= Version::V21_16 && self.thruster_banks.get(*bank_idx).map_or(false, |bank| !bank.properties.is_empty())
@@ -1952,12 +1952,12 @@ impl Model {
                         }
                     }
                 }
-                Warning::SubObjectTranslationInvalidVersion(id) => {
-                    self.version < Version::V23_01 && self.sub_objects[*id].translation_axis != SubsysTranslationAxis::None
+                Warning::SubmodelTranslationInvalidVersion(id) => {
+                    self.version < Version::V23_01 && self.submodels[*id].translation_axis != SubsysTranslationAxis::None
                 }
                 Warning::InvertedBBox(id_opt) => {
                     if let Some(id) = id_opt {
-                        self.sub_objects[*id].bbox.is_inverted()
+                        self.submodels[*id].bbox.is_inverted()
                     } else {
                         self.header.bbox.is_inverted()
                     }
@@ -1974,7 +1974,7 @@ impl Model {
                 Warning::DuplicateDetailLevel(duped_id) => self.header.detail_levels.iter().filter(|id| duped_id == *id).count() > 1,
 
                 Warning::PathNameTooLong(idx) => self.paths.get(*idx).map_or(false, |path| path.name.len() > MAX_NAME_LEN),
-                Warning::SubObjectNameTooLong(id) => self.sub_objects[*id].name.len() > MAX_NAME_LEN,
+                Warning::SubmodelNameTooLong(id) => self.submodels[*id].name.len() > MAX_NAME_LEN,
                 Warning::SpecialPointNameTooLong(idx) => self
                     .special_points
                     .get(*idx)
@@ -1989,7 +1989,7 @@ impl Model {
                     .thruster_banks
                     .get(*idx)
                     .map_or(false, |bank| bank.properties.len() > MAX_PROPERTIES_LEN),
-                Warning::SubObjectPropertiesTooLong(id) => self.sub_objects[*id].properties.len() > MAX_PROPERTIES_LEN,
+                Warning::SubmodelPropertiesTooLong(id) => self.submodels[*id].properties.len() > MAX_PROPERTIES_LEN,
                 Warning::DockingBayPropertiesTooLong(idx) => self
                     .docking_bays
                     .get(*idx)
@@ -1999,13 +1999,9 @@ impl Model {
                     .get(*idx)
                     .map_or(false, |spec_point| spec_point.properties.len() > MAX_PROPERTIES_LEN),
                 Warning::InvalidDockParentSubmodel(idx) => self.docking_bays.get(*idx).map_or(false, |dock| {
-                    properties_get_field(&dock.properties, "$parent_submodel").map_or(false, |name| self.get_obj_id_by_name(name).is_none())
+                    properties_get_field(&dock.properties, "$parent_submodel").map_or(false, |name| self.get_model_id_by_name(name).is_none())
                 }),
-                Warning::Detail0NonZeroOffset => self
-                    .header
-                    .detail_levels
-                    .get(0)
-                    .map_or(false, |id| !self.sub_objects[*id].offset.is_null()),
+                Warning::Detail0NonZeroOffset => self.header.detail_levels.get(0).map_or(false, |id| !self.submodels[*id].offset.is_null()),
             };
 
             let existing_warning = self.warnings.contains(&warning);
@@ -2029,29 +2025,29 @@ impl Model {
                 self.warnings.insert(Warning::InvertedBBox(None));
             }
 
-            for subobj in &self.sub_objects {
-                if self.bbox_test_failed(Some(subobj.obj_id)) {
-                    self.warnings.insert(Warning::BBoxTooSmall(Some(subobj.obj_id)));
+            for smodel in &self.submodels {
+                if self.bbox_test_failed(Some(smodel.id)) {
+                    self.warnings.insert(Warning::BBoxTooSmall(Some(smodel.id)));
                 }
 
-                if self.radius_test_failed(Some(subobj.obj_id)) {
-                    self.warnings.insert(Warning::RadiusTooSmall(Some(subobj.obj_id)));
+                if self.radius_test_failed(Some(smodel.id)) {
+                    self.warnings.insert(Warning::RadiusTooSmall(Some(smodel.id)));
                 }
 
-                if subobj.bbox.is_inverted() && subobj.bbox != BoundingBox::EMPTY {
-                    self.warnings.insert(Warning::InvertedBBox(Some(subobj.obj_id)));
+                if smodel.bbox.is_inverted() && smodel.bbox != BoundingBox::EMPTY {
+                    self.warnings.insert(Warning::InvertedBBox(Some(smodel.id)));
                 }
 
-                if subobj.name.len() > MAX_NAME_LEN {
-                    self.warnings.insert(Warning::SubObjectNameTooLong(subobj.obj_id));
+                if smodel.name.len() > MAX_NAME_LEN {
+                    self.warnings.insert(Warning::SubmodelNameTooLong(smodel.id));
                 }
 
-                if subobj.properties.len() > MAX_PROPERTIES_LEN {
-                    self.warnings.insert(Warning::SubObjectPropertiesTooLong(subobj.obj_id));
+                if smodel.properties.len() > MAX_PROPERTIES_LEN {
+                    self.warnings.insert(Warning::SubmodelPropertiesTooLong(smodel.id));
                 }
 
-                if self.version < Version::V23_01 && subobj.translation_axis != SubsysTranslationAxis::None {
-                    self.warnings.insert(Warning::SubObjectTranslationInvalidVersion(subobj.obj_id));
+                if self.version < Version::V23_01 && smodel.translation_axis != SubsysTranslationAxis::None {
+                    self.warnings.insert(Warning::SubmodelTranslationInvalidVersion(smodel.id));
                 }
             }
 
@@ -2068,7 +2064,7 @@ impl Model {
                     self.warnings.insert(Warning::DockingBayNameTooLong(i));
                 }
 
-                if properties_get_field(&dock.properties, "$parent_submodel").map_or(false, |name| self.get_obj_id_by_name(name).is_none()) {
+                if properties_get_field(&dock.properties, "$parent_submodel").map_or(false, |name| self.get_model_id_by_name(name).is_none()) {
                     self.warnings.insert(Warning::InvalidDockParentSubmodel(i));
                 }
             }
@@ -2139,7 +2135,7 @@ impl Model {
             }
 
             if let Some(id) = self.header.detail_levels.get(0) {
-                if !self.sub_objects[*id].offset.is_null() {
+                if !self.submodels[*id].offset.is_null() {
                     self.warnings.insert(Warning::Detail0NonZeroOffset);
                 }
             }
@@ -2162,13 +2158,13 @@ impl Model {
         }
     }
 
-    // tests if the radius for a subobject or the header is too small for its geometry
+    // tests if the radius for a submodel or the header is too small for its geometry
     // None means the header/entire model's radius
-    fn radius_test_failed(&self, subobj_opt: Option<ObjectId>) -> bool {
-        if let Some(subobj) = subobj_opt {
-            let subobj = &self.sub_objects[subobj];
-            let radius_with_margin = (1.0 + f32::EPSILON) * subobj.radius;
-            for vert in &subobj.bsp_data.verts {
+    fn radius_test_failed(&self, smodel_opt: Option<SubmodelId>) -> bool {
+        if let Some(id) = smodel_opt {
+            let smodel = &self.submodels[id];
+            let radius_with_margin = (1.0 + f32::EPSILON) * smodel.radius;
+            for vert in &smodel.bsp_data.verts {
                 if vert.magnitude() > radius_with_margin {
                     return true;
                 }
@@ -2176,14 +2172,14 @@ impl Model {
         } else {
             let radius_with_margin = (1.0 + f32::EPSILON) * self.header.max_radius;
             if let Some(&detail_0) = self.header.detail_levels.first() {
-                for subobj in &self.sub_objects {
-                    // we dont care about subobjects which aren't part of the detail0 hierarchy
-                    if !self.is_obj_id_ancestor(subobj.obj_id, detail_0) {
+                for smodel in &self.submodels {
+                    // we dont care about submodels which aren't part of the detail0 hierarchy
+                    if !self.is_model_id_ancestor(smodel.id, detail_0) {
                         continue;
                     }
 
-                    let offset = self.get_total_subobj_offset(subobj.obj_id);
-                    for vert in &subobj.bsp_data.verts {
+                    let offset = self.get_total_submodel_offset(smodel.id);
+                    for vert in &smodel.bsp_data.verts {
                         if (*vert + offset).magnitude() > radius_with_margin {
                             return true;
                         }
@@ -2195,25 +2191,25 @@ impl Model {
         false
     }
 
-    // tests if the bbox for a subobject or the header is too small for its geometry
+    // tests if the bbox for a submodel or the header is too small for its geometry
     // None means the header/entire model's radius
-    fn bbox_test_failed(&self, subobj_opt: Option<ObjectId>) -> bool {
-        if let Some(subobj) = subobj_opt {
-            let subobj = &self.sub_objects[subobj];
-            for vert in &subobj.bsp_data.verts {
-                if !subobj.bbox.contains(*vert) {
+    fn bbox_test_failed(&self, smodel_opt: Option<SubmodelId>) -> bool {
+        if let Some(id) = smodel_opt {
+            let smodel = &self.submodels[id];
+            for vert in &smodel.bsp_data.verts {
+                if !smodel.bbox.contains(*vert) {
                     return true;
                 }
             }
         } else if let Some(&detail_0) = self.header.detail_levels.first() {
-            for subobj in &self.sub_objects {
-                // we dont care about subobjects which aren't part of the detail0 hierarchy
-                if !self.is_obj_id_ancestor(subobj.obj_id, detail_0) {
+            for smodel in &self.submodels {
+                // we dont care about submodels which aren't part of the detail0 hierarchy
+                if !self.is_model_id_ancestor(smodel.id, detail_0) {
                     continue;
                 }
 
-                let offset = self.get_total_subobj_offset(subobj.obj_id);
-                for vert in &subobj.bsp_data.verts {
+                let offset = self.get_total_submodel_offset(smodel.id);
+                for vert in &smodel.bsp_data.verts {
                     if !self.header.bbox.contains(offset + *vert) {
                         return true;
                     }
@@ -2224,149 +2220,149 @@ impl Model {
         false
     }
 
-    pub fn get_total_subobj_offset(&self, id: ObjectId) -> Vec3d {
-        let mut subobj = &self.sub_objects[id];
-        let mut out = subobj.offset;
-        while let Some(parent) = subobj.parent {
-            subobj = &self.sub_objects[parent];
-            out += subobj.offset;
+    pub fn get_total_submodel_offset(&self, id: SubmodelId) -> Vec3d {
+        let mut smodel = &self.submodels[id];
+        let mut out = smodel.offset;
+        while let Some(parent) = smodel.parent {
+            smodel = &self.submodels[parent];
+            out += smodel.offset;
         }
         out
     }
 
-    // see if maybe_ancestor is actually an ancestor of obj_id in the subobject hierarchy
-    pub fn is_obj_id_ancestor(&self, obj_id: ObjectId, maybe_ancestor: ObjectId) -> bool {
+    // see if maybe_ancestor is actually an ancestor of obj_id in the submodel hierarchy
+    pub fn is_model_id_ancestor(&self, obj_id: SubmodelId, maybe_ancestor: SubmodelId) -> bool {
         if obj_id == maybe_ancestor {
             return true;
         }
 
-        let mut sub_obj_parent = self.sub_objects[obj_id].parent;
+        let mut sub_obj_parent = self.submodels[obj_id].parent;
         loop {
             if sub_obj_parent == Some(maybe_ancestor) {
                 return true;
             } else if sub_obj_parent.is_none() {
                 return false;
             }
-            assert!(sub_obj_parent != self.sub_objects[sub_obj_parent.unwrap()].parent, "cycle detected!! {:?} {:?}", obj_id, sub_obj_parent);
-            sub_obj_parent = self.sub_objects[sub_obj_parent.unwrap()].parent;
+            assert!(sub_obj_parent != self.submodels[sub_obj_parent.unwrap()].parent, "cycle detected!! {:?} {:?}", obj_id, sub_obj_parent);
+            sub_obj_parent = self.submodels[sub_obj_parent.unwrap()].parent;
         }
     }
 
-    pub fn get_sobj_detail_level(&self, obj_id: ObjectId) -> Option<u32> {
+    pub fn get_smodel_detail_level(&self, obj_id: SubmodelId) -> Option<u32> {
         for (i, id) in self.header.detail_levels.iter().enumerate() {
-            if self.is_obj_id_ancestor(obj_id, *id) {
+            if self.is_model_id_ancestor(obj_id, *id) {
                 return Some(i as u32);
             }
         }
         None
     }
 
-    pub fn get_subobj_names(&self) -> Vec<String> {
+    pub fn get_smodel_names(&self) -> Vec<String> {
         let mut ret = vec![];
-        for subobj in &self.sub_objects {
-            ret.push(subobj.name.clone());
+        for smodel in &self.submodels {
+            ret.push(smodel.name.clone());
         }
         ret
     }
 
-    pub fn get_obj_id_by_name(&self, name: &str) -> Option<ObjectId> {
-        for subobj in &self.sub_objects {
-            if subobj.name == name {
-                return Some(subobj.obj_id);
+    pub fn get_model_id_by_name(&self, name: &str) -> Option<SubmodelId> {
+        for smodel in &self.submodels {
+            if smodel.name == name {
+                return Some(smodel.id);
             }
         }
         None
     }
 
-    /// deletes a subobject without modifying other data structures, glow points, docking bays, etc
+    /// deletes a submodel without modifying other data structures, glow points, docking bays, etc
     /// this will leave stale obj id references!!!
-    pub fn delete_subobject_only(&mut self, deleted_id: ObjectId) -> (SubObject, Option<usize>) {
-        let deleted_subobj = self.sub_objects.remove(deleted_id.0 as usize);
+    pub fn delete_submodel_only(&mut self, deleted_id: SubmodelId) -> (Submodel, Option<usize>) {
+        let deleted_smodel = self.submodels.remove(deleted_id.0 as usize);
         let mut id_map = HashMap::new();
 
         // generate id mapping from old to new
-        for subobj in &self.sub_objects {
-            if subobj.obj_id.0 >= deleted_id.0 {
-                id_map.insert(subobj.obj_id, ObjectId(subobj.obj_id.0 - 1));
+        for smodel in &self.submodels {
+            if smodel.id.0 >= deleted_id.0 {
+                id_map.insert(smodel.id, SubmodelId(smodel.id.0 - 1));
             } else {
-                id_map.insert(subobj.obj_id, subobj.obj_id);
+                id_map.insert(smodel.id, smodel.id);
             }
         }
 
-        let mut deleted_subobj_child_list_index = None;
+        let mut deleted_submodel_child_list_index = None;
         // map object id references, keeping track of the newly orphaned
         let mut orphans = vec![];
-        for subobj in self.sub_objects.iter_mut() {
-            subobj.obj_id = id_map[&subobj.obj_id];
+        for smodel in self.submodels.iter_mut() {
+            smodel.id = id_map[&smodel.id];
 
             let mut i = 0;
-            subobj.children.retain_mut(|id| {
+            smodel.children.retain_mut(|id| {
                 if *id != deleted_id {
                     *id = id_map[&id];
                     i += 1;
                     true
                 } else {
-                    deleted_subobj_child_list_index = Some(i);
+                    deleted_submodel_child_list_index = Some(i);
                     i += 1;
                     false
                 }
             });
 
-            if subobj.parent == Some(deleted_id) {
-                subobj.parent = None;
-                orphans.push(subobj.obj_id);
+            if smodel.parent == Some(deleted_id) {
+                smodel.parent = None;
+                orphans.push(smodel.id);
             } else {
-                subobj.parent = subobj.parent.map(|parent_id| id_map[&parent_id]);
+                smodel.parent = smodel.parent.map(|parent_id| id_map[&parent_id]);
             }
         }
 
         // set those orphans to their grandparent, if it exists
-        if let Some(mut grand_parent_id) = deleted_subobj.parent {
+        if let Some(mut grand_parent_id) = deleted_smodel.parent {
             grand_parent_id = id_map[&grand_parent_id];
             for orphan in orphans {
-                self.sub_objects[grand_parent_id].children.push(orphan);
-                self.sub_objects[orphan].parent = Some(grand_parent_id);
+                self.submodels[grand_parent_id].children.push(orphan);
+                self.submodels[orphan].parent = Some(grand_parent_id);
             }
         }
 
-        (deleted_subobj, deleted_subobj_child_list_index)
+        (deleted_smodel, deleted_submodel_child_list_index)
     }
 
-    /// inserts a suboject into the list without modifying other data structures, glow points, docking bays, etc
-    pub fn insert_subobject_only(&mut self, inserted_subobj: SubObject, child_list_idx: Option<usize>) {
+    /// inserts a submodel into the list without modifying other data structures, glow points, docking bays, etc
+    pub fn insert_submodel_only(&mut self, inserted_submodel: Submodel, child_list_idx: Option<usize>) {
         let mut id_map = HashMap::new();
-        let inserted_id = inserted_subobj.obj_id;
-        for subobj in &self.sub_objects {
-            if subobj.obj_id >= inserted_subobj.obj_id {
-                id_map.insert(subobj.obj_id, ObjectId(subobj.obj_id.0 + 1));
+        let inserted_id = inserted_submodel.id;
+        for smodel in &self.submodels {
+            if smodel.id >= inserted_submodel.id {
+                id_map.insert(smodel.id, SubmodelId(smodel.id.0 + 1));
             } else {
-                id_map.insert(subobj.obj_id, subobj.obj_id);
+                id_map.insert(smodel.id, smodel.id);
             }
         }
 
-        for subobj in self.sub_objects.iter_mut() {
-            subobj.obj_id = id_map[&subobj.obj_id];
+        for smodel in self.submodels.iter_mut() {
+            smodel.id = id_map[&smodel.id];
 
-            for child_id in subobj.children.iter_mut() {
+            for child_id in smodel.children.iter_mut() {
                 *child_id = id_map[&child_id];
             }
 
-            if inserted_subobj.parent == Some(subobj.obj_id) {
-                subobj.children.insert(child_list_idx.unwrap(), inserted_id);
+            if inserted_submodel.parent == Some(smodel.id) {
+                smodel.children.insert(child_list_idx.unwrap(), inserted_id);
             }
 
-            if let Some(parent) = subobj.parent.as_mut() {
+            if let Some(parent) = smodel.parent.as_mut() {
                 *parent = id_map[parent];
             }
         }
 
-        self.sub_objects.insert(inserted_id.0 as usize, inserted_subobj);
+        self.submodels.insert(inserted_id.0 as usize, inserted_submodel);
 
-        for child_id in self.sub_objects[inserted_id].children.clone() {
-            if let Some(old_parent_id) = self.sub_objects[child_id].parent {
-                self.sub_objects[old_parent_id].children.retain(|x| x != &child_id);
+        for child_id in self.submodels[inserted_id].children.clone() {
+            if let Some(old_parent_id) = self.submodels[child_id].parent {
+                self.submodels[old_parent_id].children.retain(|x| x != &child_id);
             }
-            self.sub_objects[child_id].parent = Some(inserted_id);
+            self.submodels[child_id].parent = Some(inserted_id);
         }
     }
 
@@ -2392,7 +2388,7 @@ impl Model {
         }
     }
 
-    /// Computes paths to auto-generate for all turrets, `$special=subsystem` subobjects,
+    /// Computes paths to auto-generate for all turrets, `$special=subsystem` submodels,
     /// `$special=subsystem` special points, and docking bays not already covered by an
     /// existing path. Returns `(new_paths_to_append, dock_bay_assignments)`.
     /// `dock_bay_assignments` is a list of `(bay_index, PathId)` where `PathId` is the index
@@ -2418,23 +2414,23 @@ impl Model {
         // Build maps... object name to index
         let mut sobj_name_to_turret_idx: HashMap<String, usize> = HashMap::new();
         for (i, turret) in self.turrets.iter().enumerate() {
-            let base_name = self.sub_objects[turret.base_obj].name.clone();
+            let base_name = self.submodels[turret.base_model].name.clone();
             sobj_name_to_turret_idx.insert(base_name, i);
         }
 
-        let sobj_name_map: HashMap<String, usize> = self.sub_objects.iter().map(|s| (s.name.clone(), s.obj_id.0 as usize)).collect();
+        let sobj_name_map: HashMap<String, usize> = self.submodels.iter().map(|s| (s.name.clone(), s.id.0 as usize)).collect();
 
         let spcl_name_map: HashMap<String, usize> = self.special_points.iter().enumerate().map(|(i, s)| (s.name.clone(), i)).collect();
 
         // Track which objects already have paths (true = skip)
         let mut turret_has_path = vec![false; self.turrets.len()];
-        let mut sobj_has_path = vec![false; self.sub_objects.len()];
+        let mut smodel_has_path = vec![false; self.submodels.len()];
         let mut spcl_has_path = vec![false; self.special_points.len()];
 
-        // Skip non subsystem subobjects and special points, which is what PCS2 did
-        for (i, sobj) in self.sub_objects.iter().enumerate() {
+        // Skip non subsystem submodels and special points, which is what PCS2 did
+        for (i, sobj) in self.submodels.iter().enumerate() {
             if !sobj.properties.contains("$special=subsystem") {
-                sobj_has_path[i] = true;
+                smodel_has_path[i] = true;
             }
         }
         for (i, spcl) in self.special_points.iter().enumerate() {
@@ -2453,7 +2449,7 @@ impl Model {
                 spcl_has_path[si] = true;
             }
             if let Some(&oi) = sobj_name_map.get(parent) {
-                sobj_has_path[oi] = true;
+                smodel_has_path[oi] = true;
             }
         }
 
@@ -2468,8 +2464,8 @@ impl Model {
             if turret_has_path[i] {
                 continue;
             }
-            let base = &self.sub_objects[turret.base_obj];
-            let offset = self.get_total_subobj_offset(turret.base_obj);
+            let base = &self.submodels[turret.base_model];
+            let offset = self.get_total_submodel_offset(turret.base_model);
             let r = base.radius;
             let r0 = (r * 30.0_f32).min(1000.0);
             let r1 = (r * 2.0_f32).min(100.0);
@@ -2490,17 +2486,17 @@ impl Model {
                     },
                 ],
             });
-            // Mark the base_obj as covered so a subobject path is not also generated for it
-            sobj_has_path[turret.base_obj.0 as usize] = true;
+            // Mark the base_obj as covered so a submodel path is not also generated for it
+            smodel_has_path[turret.base_model.0 as usize] = true;
         }
 
-        // --- Subobjects ($special=subsystem only, not already covered by a turret path) ---
-        for sobj in self.sub_objects.iter() {
-            let idx = sobj.obj_id.0 as usize;
-            if sobj_has_path[idx] {
+        // --- Submodels ($special=subsystem only, not already covered by a turret path) ---
+        for sobj in self.submodels.iter() {
+            let idx = sobj.id.0 as usize;
+            if smodel_has_path[idx] {
                 continue;
             }
-            let offset = self.get_total_subobj_offset(sobj.obj_id);
+            let offset = self.get_total_submodel_offset(sobj.id);
             let r = sobj.radius;
             let r0 = (r * 30.0_f32).min(1000.0);
             let r1 = (r * 2.0_f32).min(100.0);
@@ -2577,7 +2573,7 @@ impl Model {
         (new_paths, dock_assignments)
     }
 
-    pub fn get_valid_gun_subobjects_for_turret(&self, existing_obj: ObjectId, turret_obj: ObjectId) -> (Vec<ObjectId>, usize) {
+    pub fn get_valid_gun_submodels_for_turret(&self, existing_obj: SubmodelId, turret_obj: SubmodelId) -> (Vec<SubmodelId>, usize) {
         let mut out_vec = vec![];
         let mut out_idx = 0;
         let mut found_existing_obj = false;
@@ -2590,7 +2586,7 @@ impl Model {
         out_vec.push(turret_obj);
 
         // then iterate through immediate base object children, which are also valid
-        for &child_id in &self.sub_objects[turret_obj].children {
+        for &child_id in &self.submodels[turret_obj].children {
             if existing_obj == child_id {
                 out_idx = out_vec.len();
                 found_existing_obj = true;
@@ -2608,18 +2604,18 @@ impl Model {
         (out_vec, out_idx)
     }
 
-    pub fn do_for_recursive_subobj_children<'a>(&'a self, id: ObjectId, f: &mut impl FnMut(&'a SubObject)) {
-        f(&self.sub_objects[id]);
+    pub fn do_for_recursive_smodel_children<'a>(&'a self, id: SubmodelId, f: &mut impl FnMut(&'a Submodel)) {
+        f(&self.submodels[id]);
 
-        for &child_id in self.sub_objects[id].children() {
-            f(&self.sub_objects[child_id]);
-            self.do_for_recursive_subobj_children(child_id, f);
+        for &child_id in self.submodels[id].children() {
+            f(&self.submodels[child_id]);
+            self.do_for_recursive_smodel_children(child_id, f);
         }
     }
 
-    pub fn num_debris_objects(&self) -> u32 {
+    pub fn num_debris_models(&self) -> u32 {
         let mut num_debris = 0;
-        for sobj in &self.sub_objects {
+        for sobj in &self.submodels {
             if sobj.is_debris_model {
                 num_debris += 1;
             }
@@ -2628,11 +2624,11 @@ impl Model {
     }
 
     pub fn apply_transform(&mut self, matrix: &TMat4<f32>) {
-        for i in 0..self.sub_objects.len() {
-            // only apply to top-level subobjects (no parent), apply_transform() will
+        for i in 0..self.submodels.len() {
+            // only apply to top-level submodels (no parent), apply_transform() will
             // recursively apply the proper transform to its children
-            if self.sub_objects[ObjectId(i as u32)].parent().is_none() {
-                self.apply_subobj_transform(ObjectId(i as u32), &matrix, true);
+            if self.submodels[SubmodelId(i as u32)].parent().is_none() {
+                self.apply_submodel_transform(SubmodelId(i as u32), &matrix, true);
             }
         }
 
@@ -2691,101 +2687,101 @@ impl Model {
         }
     }
 
-    pub fn apply_subobj_transform(&mut self, id: ObjectId, matrix: &TMat4<f32>, transform_offset: bool) {
+    pub fn apply_submodel_transform(&mut self, id: SubmodelId, matrix: &TMat4<f32>, transform_offset: bool) {
         let zero = Vec3d::ZERO.into();
         let translation = matrix.transform_point(&zero) - zero;
         let no_trans_matrix = &matrix.append_translation(&(-translation));
 
-        let subobj = &mut self.sub_objects[id];
-        subobj.radius = 0.0;
-        for vert in &mut subobj.bsp_data.verts {
+        let submodel = &mut self.submodels[id];
+        submodel.radius = 0.0;
+        for vert in &mut submodel.bsp_data.verts {
             *vert = no_trans_matrix * *vert;
             if !transform_offset {
                 *vert += translation.into();
             }
-            if vert.magnitude() > subobj.radius {
-                subobj.radius = vert.magnitude();
+            if vert.magnitude() > submodel.radius {
+                submodel.radius = vert.magnitude();
             }
         }
 
         // this preserves rotations, but inverts scales, which is the proper transformation for normals
         let norm_matrix = no_trans_matrix.try_inverse().unwrap().transpose();
 
-        for norm in &mut subobj.bsp_data.norms {
+        for norm in &mut submodel.bsp_data.norms {
             *norm = (&norm_matrix * *norm).normalize();
         }
 
-        subobj.bsp_data.collision_tree =
-            BspData::recalculate(&subobj.bsp_data.verts, std::mem::take(&mut subobj.bsp_data.collision_tree).into_leaves().map(|(_, poly)| poly));
+        submodel.bsp_data.collision_tree =
+            BspData::recalculate(&submodel.bsp_data.verts, std::mem::take(&mut submodel.bsp_data.collision_tree).into_leaves().map(|(_, poly)| poly));
 
-        subobj.bbox = *subobj.bsp_data.collision_tree.bbox();
+        submodel.bbox = *submodel.bsp_data.collision_tree.bbox();
 
         if transform_offset {
-            subobj.offset = matrix * subobj.offset;
+            submodel.offset = matrix * submodel.offset;
         }
 
-        let children = subobj.children.clone();
+        let children = submodel.children.clone();
 
         for child_id in children {
-            self.apply_subobj_transform(child_id, no_trans_matrix, true)
+            self.apply_submodel_transform(child_id, no_trans_matrix, true)
         }
     }
 
     // as above, but only affects the mesh itself
-    pub fn apply_subobj_transform_mesh(&mut self, id: ObjectId, matrix: &TMat4<f32>) {
+    pub fn apply_submodel_transform_mesh(&mut self, id: SubmodelId, matrix: &TMat4<f32>) {
         let zero = Vec3d::ZERO.into();
         let translation = matrix.transform_point(&zero) - zero;
         let no_trans_matrix = &matrix.append_translation(&(-translation));
 
-        let subobj = &mut self.sub_objects[id];
-        for vert in &mut subobj.bsp_data.verts {
+        let submodel = &mut self.submodels[id];
+        for vert in &mut submodel.bsp_data.verts {
             *vert = matrix * *vert;
         }
 
         // this preserves rotations, but inverts scales, which is the proper transformation for normals
         let norm_matrix = no_trans_matrix.try_inverse().unwrap().transpose();
 
-        for norm in &mut subobj.bsp_data.norms {
+        for norm in &mut submodel.bsp_data.norms {
             *norm = (&norm_matrix * *norm).normalize();
         }
 
-        subobj.bsp_data.collision_tree =
-            BspData::recalculate(&subobj.bsp_data.verts, std::mem::take(&mut subobj.bsp_data.collision_tree).into_leaves().map(|(_, poly)| poly));
+        submodel.bsp_data.collision_tree =
+            BspData::recalculate(&submodel.bsp_data.verts, std::mem::take(&mut submodel.bsp_data.collision_tree).into_leaves().map(|(_, poly)| poly));
     }
 
-    pub fn recalc_subobj_offset(&mut self, id: ObjectId) -> Vec3d {
-        let subobj = &mut self.sub_objects[id];
-        let new_offset = Vec3d::average(subobj.bsp_data.verts.iter().map(|vert| *vert + subobj.offset));
+    pub fn recalc_submodel_offset(&mut self, id: SubmodelId) -> Vec3d {
+        let smodel = &mut self.submodels[id];
+        let new_offset = Vec3d::average(smodel.bsp_data.verts.iter().map(|vert| *vert + smodel.offset));
         new_offset
     }
 
-    pub fn subobj_move_only_offset(&mut self, id: ObjectId, new_offset: Vec3d) {
-        let subobj = &mut self.sub_objects[id];
-        let diff = new_offset - subobj.offset;
+    pub fn submodel_move_only_offset(&mut self, id: SubmodelId, new_offset: Vec3d) {
+        let smodel = &mut self.submodels[id];
+        let diff = new_offset - smodel.offset;
 
-        let children = subobj.children.clone();
+        let children = smodel.children.clone();
         for id in &children {
-            self.sub_objects[*id].offset -= diff;
+            self.submodels[*id].offset -= diff;
         }
 
-        let subobj = &mut self.sub_objects[id];
-        subobj.bbox.max -= diff;
-        subobj.bbox.min -= diff;
-        subobj.offset = new_offset;
-        self.apply_subobj_transform(id, &glm::translation(&(-diff).into()), false);
-        self.sub_objects[id].recalc_radius();
+        let smodel = &mut self.submodels[id];
+        smodel.bbox.max -= diff;
+        smodel.bbox.min -= diff;
+        smodel.offset = new_offset;
+        self.apply_submodel_transform(id, &glm::translation(&(-diff).into()), false);
+        self.submodels[id].recalc_radius();
     }
 
     pub fn recalc_radius(&self) -> f32 {
         let mut radius = 0.00001;
         if let Some(&detail_0) = self.header.detail_levels.first() {
-            for subobj in &self.sub_objects {
-                if !self.is_obj_id_ancestor(subobj.obj_id, detail_0) {
+            for smodel in &self.submodels {
+                if !self.is_model_id_ancestor(smodel.id, detail_0) {
                     continue;
                 }
 
-                let offset = self.get_total_subobj_offset(subobj.obj_id);
-                for vert in &subobj.bsp_data.verts {
+                let offset = self.get_total_submodel_offset(smodel.id);
+                for vert in &smodel.bsp_data.verts {
                     if (*vert + offset).magnitude() > radius {
                         radius = (*vert + offset).magnitude();
                     }
@@ -2810,14 +2806,14 @@ impl Model {
         let mut bbox = BoundingBox::EMPTY;
 
         if let Some(&detail_0) = self.header.detail_levels.first() {
-            for subobj in &self.sub_objects {
-                if !self.is_obj_id_ancestor(subobj.obj_id, detail_0) {
+            for smodel in &self.submodels {
+                if !self.is_model_id_ancestor(smodel.id, detail_0) {
                     continue;
                 }
 
-                let offset = self.get_total_subobj_offset(subobj.obj_id);
-                let min = offset + subobj.bbox.min;
-                let max = offset + subobj.bbox.max;
+                let offset = self.get_total_submodel_offset(smodel.id);
+                let min = offset + smodel.bbox.min;
+                let max = offset + smodel.bbox.max;
                 bbox.min = Vec3d {
                     x: f32::min(bbox.min.x, min.x),
                     y: f32::min(bbox.min.y, min.y),
@@ -2840,12 +2836,12 @@ impl Model {
     }
 
     pub fn recalc_moi(&mut self) -> Option<Mat3d> {
-        fn sum_verts_recurse(subobjects: &ObjVec<SubObject>, id: ObjectId) -> usize {
-            subobjects[id].bsp_data.verts.len() + subobjects[id].children.iter().map(|id| sum_verts_recurse(subobjects, *id)).sum::<usize>()
+        fn sum_verts_recurse(submodels: &SubmodelVec<Submodel>, id: SubmodelId) -> usize {
+            submodels[id].bsp_data.verts.len() + submodels[id].children.iter().map(|id| sum_verts_recurse(submodels, *id)).sum::<usize>()
         }
 
         if let Some(&detail_0) = self.header.detail_levels.first() {
-            let num_verts = sum_verts_recurse(&self.sub_objects, detail_0);
+            let num_verts = sum_verts_recurse(&self.submodels, detail_0);
 
             fn add_point_mass_moi(moi: &mut Matrix3<f64>, pos: Vec3d) {
                 moi.column_mut(0).x += (pos.y * pos.y + pos.z * pos.z) as f64;
@@ -2859,14 +2855,14 @@ impl Model {
                 moi.column_mut(2).z += (pos.x * pos.x + pos.y * pos.y) as f64;
             }
 
-            fn accumulate_moi_recurse(subobjects: &ObjVec<SubObject>, id: ObjectId, moi: &mut Matrix3<f64>) {
-                subobjects[id].bsp_data.verts.iter().for_each(|vert| add_point_mass_moi(moi, *vert));
-                subobjects[id].children.iter().for_each(|id| accumulate_moi_recurse(subobjects, *id, moi));
+            fn accumulate_moi_recurse(submodels: &SubmodelVec<Submodel>, id: SubmodelId, moi: &mut Matrix3<f64>) {
+                submodels[id].bsp_data.verts.iter().for_each(|vert| add_point_mass_moi(moi, *vert));
+                submodels[id].children.iter().for_each(|id| accumulate_moi_recurse(submodels, *id, moi));
             }
 
             let mut new_moi: Matrix3<f64> = Matrix3::zeros();
 
-            accumulate_moi_recurse(&self.sub_objects, detail_0, &mut new_moi);
+            accumulate_moi_recurse(&self.submodels, detail_0, &mut new_moi);
 
             let point_mass = self.header.mass as f64 / num_verts as f64;
             new_moi *= point_mass;
@@ -2888,8 +2884,8 @@ impl Model {
             return (0.0, Vec3d::ZERO);
         };
 
-        self.do_for_recursive_subobj_children(*detail0, &mut |subobj| {
-            let (this_area, this_avg) = subobj.surface_area_average_pos();
+        self.do_for_recursive_smodel_children(*detail0, &mut |smodel| {
+            let (this_area, this_avg) = smodel.surface_area_average_pos();
             weighted_avg += this_avg * this_area;
             surface_area += this_area;
         });
@@ -2898,54 +2894,54 @@ impl Model {
     }
 
     pub fn recalc_all_children_ids(&mut self) {
-        for subobj in self.sub_objects.iter_mut() {
-            subobj.children.clear();
+        for smodel in self.submodels.iter_mut() {
+            smodel.children.clear();
         }
 
-        for i in 0..self.sub_objects.len() {
-            if let Some(parent) = self.sub_objects.0[i].parent {
-                let id = self.sub_objects.0[i].obj_id;
-                self.sub_objects[parent].children.push(id);
+        for i in 0..self.submodels.len() {
+            if let Some(parent) = self.submodels.0[i].parent {
+                let id = self.submodels.0[i].id;
+                self.submodels[parent].children.push(id);
             }
         }
     }
 
     pub fn recalc_semantic_name_links(&mut self) {
         // clear everything first
-        for subobj in self.sub_objects.iter_mut() {
-            subobj.name_links.clear();
+        for smodel in self.submodels.iter_mut() {
+            smodel.name_links.clear();
         }
 
-        for i in (0..self.sub_objects.len()).map(|i| ObjectId(i as u32)) {
-            let mut name1 = &self.sub_objects[i].name;
+        for i in (0..self.submodels.len()).map(|i| SubmodelId(i as u32)) {
+            let mut name1 = &self.submodels[i].name;
             if let Some((_, debris_of)) = name1.split_once("debris-") {
-                if let Some(obj) = self.sub_objects.iter().find(|obj| debris_of.starts_with(&obj.name)) {
-                    let j = obj.obj_id;
-                    self.sub_objects[j].name_links.push(NameLink::LiveDebris(i));
-                    self.sub_objects[i].name_links.push(NameLink::LiveDebrisOf(j));
-                    name1 = &self.sub_objects[i].name;
+                if let Some(obj) = self.submodels.iter().find(|obj| debris_of.starts_with(&obj.name)) {
+                    let j = obj.id;
+                    self.submodels[j].name_links.push(NameLink::LiveDebris(i));
+                    self.submodels[i].name_links.push(NameLink::LiveDebrisOf(j));
+                    name1 = &self.submodels[i].name;
                 }
             }
             if let Some(destroyed_of) = name1.strip_suffix("-destroyed") {
-                if let Some(obj) = self.sub_objects.iter().find(|obj| obj.name == destroyed_of) {
-                    let j = obj.obj_id;
-                    self.sub_objects[j].name_links.push(NameLink::DestroyedVersion(i));
-                    self.sub_objects[i].name_links.push(NameLink::DestroyedVersionOf(j));
-                    name1 = &self.sub_objects[i].name;
+                if let Some(obj) = self.submodels.iter().find(|obj| obj.name == destroyed_of) {
+                    let j = obj.id;
+                    self.submodels[j].name_links.push(NameLink::DestroyedVersion(i));
+                    self.submodels[i].name_links.push(NameLink::DestroyedVersionOf(j));
+                    name1 = &self.submodels[i].name;
                 }
             }
-            for j in (0..self.sub_objects.len()).map(|i| ObjectId(i as u32)) {
-                let name2 = &self.sub_objects[j].name;
-                if name1.len() == name2.len() && self.sub_objects[j].parent.is_some() && self.sub_objects[i].parent.is_some() {
+            for j in (0..self.submodels.len()).map(|i| SubmodelId(i as u32)) {
+                let name2 = &self.submodels[j].name;
+                if name1.len() == name2.len() && self.submodels[j].parent.is_some() && self.submodels[i].parent.is_some() {
                     // zip them together and filter for equal characters, leaving only the remaining, differing characters
                     let mut iter = name1.chars().zip(name2.chars()).filter(|(c1, c2)| c1 != c2);
                     // grab the characters that differ and don't continue if there's more than one,
                     // and check that they're 'a' and 'b'..='h' respectively
                     if let (Some(('a', ch @ 'b'..='h')), None) = (iter.next(), iter.next()) {
                         let level = ch as u8 - 'a' as u8;
-                        self.sub_objects[j].name_links.push(NameLink::DetailLevelOf(i, level));
-                        self.sub_objects[i].name_links.push(NameLink::DetailLevel(j, level));
-                        name1 = &self.sub_objects[i].name;
+                        self.submodels[j].name_links.push(NameLink::DetailLevelOf(i, level));
+                        self.submodels[i].name_links.push(NameLink::DetailLevel(j, level));
+                        name1 = &self.submodels[i].name;
                     }
                 }
             }
@@ -2959,28 +2955,28 @@ impl Model {
             }
         }
 
-        self.header.num_subobjects = self.sub_objects.len() as u32;
+        self.header.num_submodels = self.submodels.len() as u32;
     }
 
-    pub fn make_orphan(&mut self, would_be_orphan: ObjectId) {
-        if let Some(parent_id) = self.sub_objects[would_be_orphan].parent {
+    pub fn make_orphan(&mut self, would_be_orphan: SubmodelId) {
+        if let Some(parent_id) = self.submodels[would_be_orphan].parent {
             // maintain it's current relative position to the whole model
-            self.sub_objects[would_be_orphan].offset = self.get_total_subobj_offset(would_be_orphan);
+            self.submodels[would_be_orphan].offset = self.get_total_submodel_offset(would_be_orphan);
 
-            let parent_children = &mut self.sub_objects[parent_id].children;
+            let parent_children = &mut self.submodels[parent_id].children;
             parent_children.remove(parent_children.iter().position(|child_id| *child_id == would_be_orphan).unwrap());
         }
-        self.sub_objects[would_be_orphan].parent = None;
+        self.submodels[would_be_orphan].parent = None;
     }
 
-    pub fn make_parent(&mut self, new_parent: ObjectId, new_child: ObjectId) -> Option<()> {
-        if !self.is_obj_id_ancestor(new_parent, new_child) {
-            self.sub_objects[new_parent].children.push(new_child);
-            self.sub_objects[new_child].parent = Some(new_parent);
+    pub fn make_parent(&mut self, new_parent: SubmodelId, new_child: SubmodelId) -> Option<()> {
+        if !self.is_model_id_ancestor(new_parent, new_child) {
+            self.submodels[new_parent].children.push(new_child);
+            self.submodels[new_child].parent = Some(new_parent);
 
             // maintain it's current relative position to the whole model
-            let offset_from_parents = self.get_total_subobj_offset(new_child) - self.sub_objects[new_child].offset;
-            self.sub_objects[new_child].offset -= offset_from_parents;
+            let offset_from_parents = self.get_total_submodel_offset(new_child) - self.submodels[new_child].offset;
+            self.submodels[new_child].offset -= offset_from_parents;
 
             Some(())
         } else {
@@ -2988,7 +2984,7 @@ impl Model {
         }
     }
 
-    pub fn max_verts_norms_per_subobj(&self) -> usize {
+    pub fn max_verts_norms_per_submodel(&self) -> usize {
         if self.version >= Version::V23_00 {
             u32::MAX as usize
         } else {
@@ -3011,12 +3007,12 @@ impl Model {
 
         // turrets are more complicated, exact base + arm object name matches only
         import_model.turrets.retain_mut(|turret| {
-            for subobj in &self.sub_objects {
-                if import_model.sub_objects[turret.base_obj].name == subobj.name
-                    && self.get_obj_id_by_name(&import_model.sub_objects[turret.gun_obj].name).is_some()
+            for smodel in &self.submodels {
+                if import_model.submodels[turret.base_model].name == smodel.name
+                    && self.get_model_id_by_name(&import_model.submodels[turret.gun_model].name).is_some()
                 {
-                    turret.base_obj = subobj.obj_id;
-                    turret.gun_obj = self.get_obj_id_by_name(&import_model.sub_objects[turret.gun_obj].name).unwrap();
+                    turret.base_model = smodel.id;
+                    turret.gun_model = self.get_model_id_by_name(&import_model.submodels[turret.gun_model].name).unwrap();
                     return true;
                 }
             }
@@ -3030,7 +3026,7 @@ impl Model {
 
     pub fn turret_matrix(&self, turret_idx: usize) -> TMat4<f32> {
         let turret = &self.turrets[turret_idx];
-        let mut arr = if let Some((uvec, fvec)) = self.sub_objects[turret.base_obj].uvec_fvec() {
+        let mut arr = if let Some((uvec, fvec)) = self.submodels[turret.base_model].uvec_fvec() {
             [uvec.into(), fvec.into()]
         } else {
             [turret.normal.0.into(), Vec3d::new(0.0, 0.0, 1.0).into()]
@@ -3055,31 +3051,31 @@ pub enum Set<T> {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
 pub enum Error {
-    InvalidTurretGunSubobject(usize), // turret index
-    TooManyDebrisObjects,
-    DetailObjWithParent(ObjectId),
-    DetailAndDebrisObj(ObjectId),
-    TooManyVerts(ObjectId),
-    TooManyNorms(ObjectId),
-    UnnamedSubObject(ObjectId),
-    DuplicateSubobjectName(String),
+    InvalidTurretGunSubmodel(usize), // turret index
+    TooManyDebrisModels,
+    DetailModelWithParent(SubmodelId),
+    DetailAndDebrisModel(SubmodelId),
+    TooManyVerts(SubmodelId),
+    TooManyNorms(SubmodelId),
+    UnnamedSubmodel(SubmodelId),
+    DuplicateSubmodelName(String),
     // all turret base/gun objects must be disjoint!
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub enum Warning {
-    RadiusTooSmall(Option<ObjectId>),
-    BBoxTooSmall(Option<ObjectId>),
-    InvertedBBox(Option<ObjectId>),
+    RadiusTooSmall(Option<SubmodelId>),
+    BBoxTooSmall(Option<SubmodelId>),
+    InvertedBBox(Option<SubmodelId>),
     UntexturedPolygons,
     DockingBayWithoutPath(usize),
     ThrusterPropertiesInvalidVersion(usize),
     WeaponOffsetInvalidVersion { primary: bool, bank: usize, point: usize },
-    SubObjectTranslationInvalidVersion(ObjectId),
+    SubmodelTranslationInvalidVersion(SubmodelId),
     TooFewTurretFirePoints(usize),
     TooManyTurretFirePoints(usize),
     DuplicatePathName(String),
-    DuplicateDetailLevel(ObjectId),
+    DuplicateDetailLevel(SubmodelId),
     TooManyEyePoints,
     TooManyTextures,
     InvalidDockParentSubmodel(usize),
@@ -3087,10 +3083,10 @@ pub enum Warning {
 
     PathNameTooLong(usize),
     SpecialPointNameTooLong(usize),
-    SubObjectNameTooLong(ObjectId),
+    SubmodelNameTooLong(SubmodelId),
     DockingBayNameTooLong(usize),
 
-    SubObjectPropertiesTooLong(ObjectId),
+    SubmodelPropertiesTooLong(SubmodelId),
     ThrusterPropertiesTooLong(usize),
     DockingBayPropertiesTooLong(usize),
     GlowBankPropertiesTooLong(usize),
@@ -3098,20 +3094,20 @@ pub enum Warning {
     // path with no parent
     // thruster with no engine subsys (and an engine subsys exists)
     // turret uvec != turret normal
-    // turret subobject properties not set up for a turret
+    // turret submodel properties not set up for a turret
     // turret without 'turret' in name
     // nonturret with 'turret' in name
 }
 
-pub fn post_parse_fill_untextured_slot(sub_objects: &mut Vec<SubObject>, textures: &mut Vec<String>) -> Option<TextureId> {
+pub fn post_parse_fill_untextured_slot(sub_objects: &mut Vec<Submodel>, textures: &mut Vec<String>) -> Option<TextureId> {
     let max_texture = TextureId(textures.len().try_into().unwrap());
     let untextured_id = match textures.iter().position(|tex| tex == "Untextured") {
         Some(index) => TextureId(index.try_into().unwrap()),
         None => max_texture,
     };
     let mut has_untextured = false;
-    for subobj in sub_objects.iter_mut() {
-        for (_, poly) in subobj.bsp_data.collision_tree.leaves_mut() {
+    for smodel in sub_objects.iter_mut() {
+        for (_, poly) in smodel.bsp_data.collision_tree.leaves_mut() {
             if poly.texture >= max_texture {
                 has_untextured = true;
                 poly.texture = untextured_id;

--- a/pof/src/write.rs
+++ b/pof/src/write.rs
@@ -16,8 +16,8 @@ use json::Index;
 extern crate nalgebra_glm as glm;
 
 use crate::{
-    BoundingBox, BspData, BspNode, Dock, EyePoint, GlowPointBank, Insignia, Model, ObjVec, ObjectId, Path, ShieldData, ShieldNode, SpecialPoint,
-    SubObject, ThrusterBank, Turret, Vec3d, Version, WeaponHardpoint,
+    BoundingBox, BspData, BspNode, Dock, EyePoint, GlowPointBank, Insignia, Model, Path, ShieldData, ShieldNode, SpecialPoint, Submodel, SubmodelId,
+    SubmodelVec, ThrusterBank, Turret, Vec3d, Version, WeaponHardpoint,
 };
 
 pub(crate) trait Serialize {
@@ -353,23 +353,23 @@ fn write_chunk_vec<T: Serialize>(w: &mut impl Write, chunk_name: &[u8; 4], data:
     Ok(())
 }
 
-fn write_subobjects(w: &mut impl Write, chunk_name: &[u8; 4], objects: &[SubObject]) -> io::Result<()> {
-    fn write_subobject(w: &mut impl Write, chunk_name: [u8; 4], objects: &[SubObject], written: &mut [bool], id: ObjectId) -> io::Result<()> {
+fn write_submodels(w: &mut impl Write, chunk_name: &[u8; 4], submodels: &[Submodel]) -> io::Result<()> {
+    fn write_submodel(w: &mut impl Write, chunk_name: [u8; 4], submodels: &[Submodel], written: &mut [bool], id: SubmodelId) -> io::Result<()> {
         if !written[id.0 as usize] {
-            let obj = &objects[id.0 as usize];
+            let smodel = &submodels[id.0 as usize];
             // ensure parents are written before children
-            if let Some(parent) = obj.parent {
-                write_subobject(w, chunk_name, objects, written, parent)?;
+            if let Some(parent) = smodel.parent {
+                write_submodel(w, chunk_name, submodels, written, parent)?;
             }
-            write_chunk(w, &chunk_name, Some(obj))?;
+            write_chunk(w, &chunk_name, Some(smodel))?;
             written[id.0 as usize] = true;
         }
         Ok(())
     }
 
-    let mut written = vec![false; objects.len()];
-    for i in 0..objects.len() as u32 {
-        write_subobject(w, *chunk_name, objects, &mut written, ObjectId(i))?;
+    let mut written = vec![false; submodels.len()];
+    for i in 0..submodels.len() as u32 {
+        write_submodel(w, *chunk_name, submodels, &mut written, SubmodelId(i))?;
     }
     Ok(())
 }
@@ -388,18 +388,18 @@ impl Model {
             if self.version >= Version::V21_16 {
                 self.header.max_radius.write_to(w)?;
                 self.header.obj_flags.write_to(w)?;
-                self.header.num_subobjects.write_to(w)?;
+                self.header.num_submodels.write_to(w)?;
             } else {
-                self.header.num_subobjects.write_to(w)?;
+                self.header.num_submodels.write_to(w)?;
                 self.header.max_radius.write_to(w)?;
                 self.header.obj_flags.write_to(w)?;
             }
             self.header.bbox.write_to(w)?;
             self.header.detail_levels.write_to(w)?;
-            self.sub_objects
+            self.submodels
                 .iter()
-                .filter(|obj| obj.is_debris_model)
-                .map(|obj| obj.obj_id)
+                .filter(|smodel| smodel.is_debris_model)
+                .map(|smodel| smodel.id)
                 .collect::<Vec<_>>()
                 .write_to(w)?;
             if self.version >= Version::V20_09 {
@@ -422,7 +422,7 @@ impl Model {
             }
             Ok(())
         })?;
-        write_subobjects(w, if self.version >= Version::V21_16 { b"OBJ2" } else { b"SOBJ" }, &self.sub_objects)?;
+        write_submodels(w, if self.version >= Version::V21_16 { b"OBJ2" } else { b"SOBJ" }, &self.submodels)?;
         write_chunk_vec(w, b"TXTR", &self.textures)?;
         write_chunk_vec(w, b"PATH", &self.paths)?;
         write_chunk_vec(w, b"SPCL", &self.special_points)?;
@@ -693,7 +693,7 @@ fn make_glows_node<N: Node>(ctx: &mut N::Ctx, glows: &[GlowPointBank], up: UpAxi
         bank_node.children().extend([
             N::from_name(format!("#g{}-type", i), format!("#g{}-type:{}", i, glow_bank.glow_type)).build(ctx),
             N::from_name(format!("#g{}-lod", i), format!("#g{}-lod:{}", i, glow_bank.lod)).build(ctx),
-            N::from_name(format!("#g{}-parent", i), format!("#g{}-parent:{}", i, glow_bank.obj_parent.0)).build(ctx),
+            N::from_name(format!("#g{}-parent", i), format!("#g{}-parent:{}", i, glow_bank.model_parent.0)).build(ctx),
             N::from_name(format!("#g{}-ontime", i), format!("#g{}-ontime:{}", i, glow_bank.on_time)).build(ctx),
             N::from_name(format!("#g{}-offtime", i), format!("#g{}-offtime:{}", i, glow_bank.off_time)).build(ctx),
             N::from_name(format!("#g{}-disptime", i), format!("#g{}-disptime:{}", i, glow_bank.disp_time)).build(ctx),
@@ -744,7 +744,7 @@ fn make_eyes_node<N: Node>(ctx: &mut N::Ctx, eye_points: &[EyePoint], up: UpAxis
         point_node.translate(pos.into());
         point_node.rotate(vec_to_rotation(&point.normal.0, up));
 
-        if let Some(id) = point.attached_subobj {
+        if let Some(id) = point.attached_submodel {
             point_node
                 .children()
                 .push(N::from_name(format!("#e{}-parent", i), format!("#e{}-parent:{}", i, id.0)).build(ctx));
@@ -879,25 +879,25 @@ fn make_shield_node(shield: &ShieldData, geometries: &mut Vec<Geometry>, up: UpA
     node
 }
 
-fn make_subobj_node(
-    up: UpAxis, subobjs: &ObjVec<SubObject>, subobj: &SubObject, turrets: &[Turret], geometries: &mut Vec<Geometry>, materials: &[String],
+fn make_submodel_node(
+    up: UpAxis, submodels: &SubmodelVec<Submodel>, submodel: &Submodel, turrets: &[Turret], geometries: &mut Vec<Geometry>, materials: &[String],
 ) -> DaeNode {
-    let geo_id = format!("{}-geometry", subobj.name);
-    let pos_id = format!("{}-geometry-position", subobj.name);
-    let vert_id = format!("{}-geometry-vertex", subobj.name);
+    let geo_id = format!("{}-geometry", submodel.name);
+    let pos_id = format!("{}-geometry-position", submodel.name);
+    let vert_id = format!("{}-geometry-vertex", submodel.name);
     let pos_array_id = format!("{}-array", pos_id);
-    let norm_id = format!("{}-geometry-normal", subobj.name);
+    let norm_id = format!("{}-geometry-normal", submodel.name);
     let norm_array_id = format!("{}-array", norm_id);
-    let uv_id = format!("{}-geometry-uv", subobj.name);
+    let uv_id = format!("{}-geometry-uv", submodel.name);
     let uv_array_id = format!("{}-array", uv_id);
 
     let mut positions = vec![];
-    for vert in &subobj.bsp_data.verts {
+    for vert in &submodel.bsp_data.verts {
         positions.extend_from_slice(&<[_; 3]>::from(vert.to_coord(up)));
     }
 
     let mut normals = vec![];
-    for norm in &subobj.bsp_data.norms {
+    for norm in &submodel.bsp_data.norms {
         normals.extend_from_slice(&<[_; 3]>::from(norm.to_coord(up)));
     }
 
@@ -905,7 +905,7 @@ fn make_subobj_node(
     let mut uv_len = 0;
     let mut prim_elems = vec![(vec![], vec![]); materials.len() + 1];
 
-    for (_, poly) in subobj.bsp_data.collision_tree.leaves() {
+    for (_, poly) in submodel.bsp_data.collision_tree.leaves() {
         let (vert_count, indices) = &mut prim_elems[poly.texture.0 as usize + 1];
         vert_count.push(poly.verts.len() as u32);
         for vert in poly.verts.iter().rev() {
@@ -961,14 +961,14 @@ fn make_subobj_node(
             .collect(),
     ));
 
-    let mut node = DaeNode::from_id(subobj.name.clone());
-    node.translate(subobj.offset.to_coord(up).into());
+    let mut node = DaeNode::from_id(submodel.name.clone());
+    node.translate(submodel.offset.to_coord(up).into());
 
-    // kind of expensive to do per subobj?
+    // kind of expensive to do per submodel?
     for (i, turret) in turrets.iter().enumerate() {
-        if turret.gun_obj == subobj.obj_id {
+        if turret.gun_model == submodel.id {
             for (j, point) in turret.fire_points.iter().enumerate() {
-                let name = if turret.base_obj == subobj.obj_id {
+                let name = if turret.base_model == submodel.id {
                     format!("#t{}-point{}", i, j)
                 } else {
                     format!("#t{}-gun-point{}", i, j)
@@ -982,37 +982,45 @@ fn make_subobj_node(
         }
     }
 
-    if !subobj.properties.is_empty() {
+    if !submodel.properties.is_empty() {
         node.children
-            .push(make_properties_node(&mut (), &subobj.properties, format!("{}-", subobj.name)));
+            .push(make_properties_node(&mut (), &submodel.properties, format!("{}-", submodel.name)));
     }
 
-    if subobj.rotation_type != Default::default() {
-        node.children
-            .push(DaeNode::new(format!("{}-mov-type", subobj.name), Some(format!("#{}-mov-type:{}", subobj.name, subobj.rotation_type as i32))));
+    if submodel.rotation_type != Default::default() {
+        node.children.push(DaeNode::new(
+            format!("{}-mov-type", submodel.name),
+            Some(format!("#{}-mov-type:{}", submodel.name, submodel.rotation_type as i32)),
+        ));
     }
 
-    if subobj.rotation_axis != Default::default() {
-        node.children
-            .push(DaeNode::new(format!("{}-mov-axis", subobj.name), Some(format!("#{}-mov-axis:{}", subobj.name, subobj.rotation_axis as i32))));
+    if submodel.rotation_axis != Default::default() {
+        node.children.push(DaeNode::new(
+            format!("{}-mov-axis", submodel.name),
+            Some(format!("#{}-mov-axis:{}", submodel.name, submodel.rotation_axis as i32)),
+        ));
     }
 
-    if subobj.translation_type != Default::default() {
-        node.children
-            .push(DaeNode::new(format!("{}-mov-type", subobj.name), Some(format!("#{}-trans-type:{}", subobj.name, subobj.translation_type as i32))));
+    if submodel.translation_type != Default::default() {
+        node.children.push(DaeNode::new(
+            format!("{}-mov-type", submodel.name),
+            Some(format!("#{}-trans-type:{}", submodel.name, submodel.translation_type as i32)),
+        ));
     }
 
-    if subobj.translation_axis != Default::default() {
-        node.children
-            .push(DaeNode::new(format!("{}-mov-axis", subobj.name), Some(format!("#{}-trans-axis:{}", subobj.name, subobj.translation_axis as i32))));
+    if submodel.translation_axis != Default::default() {
+        node.children.push(DaeNode::new(
+            format!("{}-mov-axis", submodel.name),
+            Some(format!("#{}-trans-axis:{}", submodel.name, submodel.translation_axis as i32)),
+        ));
     }
 
     node.instance_geometry.push(instance);
     node.children.extend(
-        subobj
+        submodel
             .children
             .iter()
-            .map(|&id| make_subobj_node(up, subobjs, &subobjs[id], turrets, geometries, materials)),
+            .map(|&id| make_submodel_node(up, submodels, &submodels[id], turrets, geometries, materials)),
     );
 
     node
@@ -1027,12 +1035,12 @@ impl Model {
 
         let up = UpAxis::YUp;
 
-        for subobj in &self.sub_objects {
-            if subobj.parent.is_none() {
-                let mut top_level_node = make_subobj_node(up, &self.sub_objects, subobj, &self.turrets, &mut geometries, &materials);
+        for submodel in &self.submodels {
+            if submodel.parent.is_none() {
+                let mut top_level_node = make_submodel_node(up, &self.submodels, submodel, &self.turrets, &mut geometries, &materials);
 
                 for (i, insignia) in self.insignias.iter().enumerate() {
-                    if self.get_sobj_detail_level(subobj.obj_id) == Some(insignia.detail_level) {
+                    if self.get_smodel_detail_level(submodel.id) == Some(insignia.detail_level) {
                         top_level_node.children.push(make_insignia_node(insignia, &mut geometries, i, up))
                     }
                 }
@@ -1324,9 +1332,9 @@ impl GltfBuilder {
         node.build(&mut self.root.nodes)
     }
 
-    fn make_subobj_node(&mut self, subobjs: &ObjVec<SubObject>, subobj: &SubObject, turrets: &[Turret], materials: usize) -> json::Node {
+    fn make_submodel_node(&mut self, submodels: &SubmodelVec<Submodel>, submodel: &Submodel, turrets: &[Turret], materials: usize) -> json::Node {
         let mut prim_elems = vec![vec![]; materials];
-        for (_, poly) in subobj.bsp_data.collision_tree.leaves() {
+        for (_, poly) in submodel.bsp_data.collision_tree.leaves() {
             if let [vert1, rest @ ..] = &*poly.verts {
                 let tris = &mut prim_elems[poly.texture.0 as usize];
                 for verts in rest.windows(2) {
@@ -1346,8 +1354,8 @@ impl GltfBuilder {
                 let view = self.push_buffer_view(start, size_of::<(Vec3d, Vec3d, [f32; 2])>(), false, count, Target::ArrayBuffer);
                 let mut bbox_pos = BoundingBox::EMPTY;
                 for vert in prim_elem.into_iter().flatten() {
-                    let position = subobj.bsp_data.verts[vert.vertex_id.0 as usize].to_coord(up);
-                    let normal = subobj.bsp_data.norms[vert.normal_id.0 as usize].to_coord(up);
+                    let position = submodel.bsp_data.verts[vert.vertex_id.0 as usize].to_coord(up);
+                    let normal = submodel.bsp_data.norms[vert.normal_id.0 as usize].to_coord(up);
                     bbox_pos.expand_vec(position);
                     (position, normal, vert.uv).write_to(&mut self.buffer).unwrap();
                 }
@@ -1379,14 +1387,14 @@ impl GltfBuilder {
 
         let geo_id = self.push_mesh(primitives);
 
-        let mut node = NodeIndex::from_id(subobj.name.clone());
-        node.translate(subobj.offset.to_coord(up).into());
+        let mut node = NodeIndex::from_id(submodel.name.clone());
+        node.translate(submodel.offset.to_coord(up).into());
 
-        // kind of expensive to do per subobj?
+        // kind of expensive to do per submodel?
         for (i, turret) in turrets.iter().enumerate() {
-            if turret.gun_obj == subobj.obj_id {
+            if turret.gun_model == submodel.id {
                 for (j, point) in turret.fire_points.iter().enumerate() {
-                    let name = if turret.base_obj == subobj.obj_id {
+                    let name = if turret.base_model == submodel.id {
                         format!("#t{}-point{}", i, j)
                     } else {
                         format!("#t{}-gun-point{}", i, j)
@@ -1400,25 +1408,25 @@ impl GltfBuilder {
             }
         }
 
-        if !subobj.properties.is_empty() {
+        if !submodel.properties.is_empty() {
             node.children()
-                .push(make_properties_node(&mut self.root.nodes, &subobj.properties, format!("{}-", subobj.name)));
+                .push(make_properties_node(&mut self.root.nodes, &submodel.properties, format!("{}-", submodel.name)));
         }
 
-        if subobj.rotation_type != Default::default() {
+        if submodel.rotation_type != Default::default() {
             node.children()
-                .push(NodeIndex::from_id(format!("#{}-mov-type:{}", subobj.name, subobj.rotation_type as i32)).build(&mut self.root.nodes));
+                .push(NodeIndex::from_id(format!("#{}-mov-type:{}", submodel.name, submodel.rotation_type as i32)).build(&mut self.root.nodes));
         }
 
-        if subobj.rotation_axis != Default::default() {
+        if submodel.rotation_axis != Default::default() {
             node.children()
-                .push(NodeIndex::from_id(format!("#{}-mov-axis:{}", subobj.name, subobj.rotation_axis as i32)).build(&mut self.root.nodes));
+                .push(NodeIndex::from_id(format!("#{}-mov-axis:{}", submodel.name, submodel.rotation_axis as i32)).build(&mut self.root.nodes));
         }
 
         node.mesh = Some(geo_id);
-        for &id in &subobj.children {
+        for &id in &submodel.children {
             node.children().push(
-                self.make_subobj_node(subobjs, &subobjs[id], turrets, materials)
+                self.make_submodel_node(submodels, &submodels[id], turrets, materials)
                     .build(&mut self.root.nodes),
             );
         }
@@ -1461,12 +1469,12 @@ impl GltfBuilder {
 
         let mut nodes = vec![];
 
-        for subobj in &model.sub_objects {
-            if subobj.parent.is_none() {
-                let mut top_level_node = self.make_subobj_node(&model.sub_objects, subobj, &model.turrets, model.textures.len());
+        for submodel in &model.submodels {
+            if submodel.parent.is_none() {
+                let mut top_level_node = self.make_submodel_node(&model.submodels, submodel, &model.turrets, model.textures.len());
 
                 for (i, insignia) in model.insignias.iter().enumerate() {
-                    if model.get_sobj_detail_level(subobj.obj_id) == Some(insignia.detail_level) {
+                    if model.get_smodel_detail_level(submodel.id) == Some(insignia.detail_level) {
                         top_level_node.children().push(self.make_insignia_node(insignia, i, up))
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use crate::{
     primitives::OCTAHEDRON_VERTS,
     ui::{
         DisplayMode, DockingTreeValue, DragAxis, EyeTreeValue, GlowTreeValue, InsigniaTreeValue, PathTreeValue, SpecialPointTreeValue,
-        SubObjectTreeValue, TextureTreeValue, ThrusterTreeValue, TurretTreeValue, UndoAction, WeaponTreeValue,
+        SubmodelTreeValue, TextureTreeValue, ThrusterTreeValue, TurretTreeValue, UndoAction, WeaponTreeValue,
     },
 };
 use eframe::egui::PointerButton;
@@ -22,8 +22,8 @@ use glium::{glutin::surface::WindowSurface, texture::SrgbTexture2d, BlendingFunc
 use glm::{Mat4x4, TMat4};
 use native_dialog::FileDialog;
 use pof::{
-    properties_get_field, BspData, Insignia, NameLink, NormalId, NormalVec3, ObjVec, ObjectId, Parser, PolyVertex, Polygon, Set, ShieldData,
-    SubObject, TextureId, Vec3d, VertexId,
+    properties_get_field, BspData, Insignia, NameLink, NormalId, NormalVec3, Parser, PolyVertex, Polygon, Set, ShieldData, Submodel, SubmodelId,
+    SubmodelVec, TextureId, Vec3d, VertexId,
 };
 use simplelog::*;
 use std::{
@@ -209,13 +209,13 @@ impl GlBufferedInsignia {
 }
 
 #[derive(Default)]
-struct GlObjectBuilder {
+struct GlMeshBuilder {
     vertices: Vec<Vertex>,
     normals: Vec<Normal>,
     map: HashMap<(VertexId, NormalId, u32, u32), u32>,
 }
 
-impl GlObjectBuilder {
+impl GlMeshBuilder {
     fn get_index(&mut self, bsp_data: &BspData, vert: &PolyVertex) -> u32 {
         *self
             .map
@@ -233,13 +233,13 @@ impl GlObjectBuilder {
 }
 
 #[derive(Default)]
-struct GlObjectsBuilder {
-    inner: GlObjectBuilder,
+struct GlMeshesBuilder {
+    inner: GlMeshBuilder,
     indices: Vec<u32>,
     wireframe_indices: Vec<u32>,
 }
 
-impl GlObjectsBuilder {
+impl GlMeshesBuilder {
     fn push(&mut self, bsp_data: &BspData, poly: &Polygon) {
         // need to triangulate possibly
         // we'll make tris like this 0,1,2 .. 0,2,3 .. 0,3,4... etc
@@ -286,10 +286,10 @@ impl GlObjectsBuilder {
         }
     }
 
-    fn finish(self, display: &Display<WindowSurface>, object: &SubObject, texture_id: Option<TextureId>, out: &mut Vec<GlObjectBuffer>) {
+    fn finish(self, display: &Display<WindowSurface>, smodel: &Submodel, texture_id: Option<TextureId>, out: &mut Vec<GlMeshBuffer>) {
         if !self.indices.is_empty() {
-            info!("Built buffer for subobj {}", object.name);
-            out.push(GlObjectBuffer {
+            info!("Built buffer for submodel {}", smodel.name);
+            out.push(GlMeshBuffer {
                 texture_id,
                 vertices: glium::VertexBuffer::new(display, &self.inner.vertices).unwrap(),
                 normals: glium::VertexBuffer::new(display, &self.inner.normals).unwrap(),
@@ -305,7 +305,7 @@ impl GlObjectsBuilder {
     }
 }
 
-struct GlObjectBuffer {
+struct GlMeshBuffer {
     texture_id: Option<TextureId>,
     vertices: VertexBuffer<Vertex>,
     normals: VertexBuffer<Normal>,
@@ -314,15 +314,15 @@ struct GlObjectBuffer {
     tint_val: f32,
 }
 
-struct GlObjectBuffers {
-    buffers: Vec<GlObjectBuffer>,
+struct GlMeshBuffers {
+    buffers: Vec<GlMeshBuffer>,
 }
 
-impl GlObjectBuffers {
-    fn new(display: &Display<WindowSurface>, object: &SubObject, num_textures: usize) -> Self {
-        let mut textures = Vec::from_iter(std::iter::repeat_with(GlObjectsBuilder::default).take(num_textures));
+impl GlMeshBuffers {
+    fn new(display: &Display<WindowSurface>, smodel: &Submodel, num_textures: usize) -> Self {
+        let mut textures = Vec::from_iter(std::iter::repeat_with(GlMeshesBuilder::default).take(num_textures));
 
-        let bsp_data = &object.bsp_data;
+        let bsp_data = &smodel.bsp_data;
 
         for (_, poly) in bsp_data.collision_tree.leaves() {
             textures[poly.texture.0 as usize].push(bsp_data, poly);
@@ -330,13 +330,13 @@ impl GlObjectBuffers {
 
         let mut buffers = vec![];
         for (i, builder) in textures.into_iter().enumerate() {
-            builder.finish(display, object, Some(TextureId(i as u32)), &mut buffers)
+            builder.finish(display, smodel, Some(TextureId(i as u32)), &mut buffers)
         }
         Self { buffers }
     }
 
     fn clone(&self, display: &Display<WindowSurface>) -> Self {
-        let mut new_bufs = GlObjectBuffers { buffers: vec![] };
+        let mut new_bufs = GlMeshBuffers { buffers: vec![] };
         for buf in &self.buffers {
             let vertices = glium::VertexBuffer::empty(display, buf.vertices.len()).unwrap();
             buf.vertices.copy_to(vertices.as_slice()).unwrap();
@@ -353,7 +353,7 @@ impl GlObjectBuffers {
                 wireframe_indices = Some(new_buf);
             }
 
-            new_bufs.buffers.push(GlObjectBuffer {
+            new_bufs.buffers.push(GlMeshBuffer {
                 texture_id: buf.texture_id,
                 vertices,
                 normals,
@@ -395,8 +395,9 @@ pub struct Model {
     /// Annoying, but 'merge' textures is best handled as simply filling this map and deferring the actual task
     /// of merging textures until write
     texture_map: HashMap<TextureId, TextureId>,
-    subobject_transform_matrix: ObjVec<TMat4<f32>>,
-    buffer_objects: ObjVec<GlObjectBuffers>, // all the subobjects, conditionally rendered based on the current tree selection
+    submodel_transform_matrix: SubmodelVec<TMat4<f32>>,
+    submodel_duplicated: SubmodelVec<bool>,
+    buffer_meshes: SubmodelVec<GlMeshBuffers>, // all the submodels, conditionally rendered based on the current tree selection
 }
 impl Deref for Model {
     type Target = pof::Model;
@@ -413,15 +414,15 @@ impl DerefMut for Model {
 impl Model {
     pub fn clean_up(&mut self) {
         // apply changes form the texture map
-        for subobj in self.pof_model.sub_objects.iter_mut() {
-            for (_, poly) in subobj.bsp_data.collision_tree.leaves_mut() {
+        for smodel in self.pof_model.submodels.iter_mut() {
+            for (_, poly) in smodel.bsp_data.collision_tree.leaves_mut() {
                 poly.texture = self.texture_map[&poly.texture];
             }
         }
 
-        for id in 0..self.pof_model.sub_objects.len() {
-            let id = ObjectId(id as u32);
-            self.pof_model.apply_subobj_transform_mesh(id, &self.subobject_transform_matrix[id]);
+        for id in 0..self.pof_model.submodels.len() {
+            let id = SubmodelId(id as u32);
+            self.pof_model.apply_submodel_transform_mesh(id, &self.submodel_transform_matrix[id]);
         }
 
         self.pof_model.clean_up();
@@ -535,8 +536,9 @@ impl PofToolsGui {
                     self.model = Box::new(Model {
                         pof_model: *data,
                         texture_map: HashMap::new(),
-                        subobject_transform_matrix: Default::default(),
-                        buffer_objects: Default::default(),
+                        submodel_transform_matrix: Default::default(),
+                        submodel_duplicated: Default::default(),
+                        buffer_meshes: Default::default(),
                     });
                     self.finish_loading_model(window, display);
 
@@ -556,14 +558,14 @@ impl PofToolsGui {
 
     // after the above thread has returned, stuffs the new model in
     fn finish_loading_model(&mut self, window: &Window, display: &Display<WindowSurface>) {
-        self.model.buffer_objects.clear();
+        self.model.buffer_meshes.clear();
         self.buffer_shield = None;
         self.buffer_insignias.clear();
 
-        for subobject in &self.model.pof_model.sub_objects {
+        for submodel in &self.model.pof_model.submodels {
             self.model
-                .buffer_objects
-                .push(GlObjectBuffers::new(display, subobject, self.model.pof_model.textures.len()));
+                .buffer_meshes
+                .push(GlMeshBuffers::new(display, submodel, self.model.pof_model.textures.len()));
         }
 
         for insignia in &self.model.insignias {
@@ -574,8 +576,9 @@ impl PofToolsGui {
             self.buffer_shield = Some(GlBufferedShield::new(display, shield));
         }
 
-        for _ in 0..self.model.sub_objects.len() {
-            self.model.subobject_transform_matrix.push(glm::identity());
+        for _ in 0..self.model.submodels.len() {
+            self.model.submodel_transform_matrix.push(glm::identity());
+            self.model.submodel_duplicated.push(false);
         }
         self.model.recheck_warnings(pof::Set::All);
         self.model.recheck_errors(pof::Set::All);
@@ -589,7 +592,7 @@ impl PofToolsGui {
         self.camera_pitch = -0.4;
         self.camera_offset = Vec3d::ZERO;
         self.camera_scale = self.model.header.max_radius * 1.5;
-        self.ui_state.last_selected_subobj = self.model.header.detail_levels.first().copied();
+        self.ui_state.last_selected_smodel = self.model.header.detail_levels.first().copied();
         self.ui_state.tree_view_selection = TreeValue::Header;
 
         self.maybe_recalculate_3d_helpers(display);
@@ -766,10 +769,10 @@ fn main() {
                         pt_gui.ui_state.refresh_properties_panel(&pt_gui.model);
                         if pt_gui
                             .ui_state
-                            .last_selected_subobj
-                            .is_some_and(|id| id.0 as usize >= pt_gui.model.sub_objects.len())
+                            .last_selected_smodel
+                            .is_some_and(|id| id.0 as usize >= pt_gui.model.submodels.len())
                         {
-                            pt_gui.ui_state.last_selected_subobj = pt_gui.model.header.detail_levels.first().copied();
+                            pt_gui.ui_state.last_selected_smodel = pt_gui.model.header.detail_levels.first().copied();
                         }
                     }
 
@@ -890,7 +893,7 @@ fn main() {
                                     };
                                     pt_gui.drag_start = *lollipop.get_position_ref(&mut pt_gui.model).unwrap();
                                     if let TreeValue::Turrets(TurretTreeValue::TurretPoint(i, _)) = lollipop {
-                                        pt_gui.drag_start += pt_gui.model.get_total_subobj_offset(pt_gui.model.turrets[i].gun_obj);
+                                        pt_gui.drag_start += pt_gui.model.get_total_submodel_offset(pt_gui.model.turrets[i].gun_model);
                                     }
 
                                     pt_gui.select_new_tree_val(lollipop);
@@ -918,7 +921,7 @@ fn main() {
                             // take into account turret offset
                             let mut maybe_turret_offset = Vec3d::ZERO;
                             if let Some(TreeValue::Turrets(TurretTreeValue::TurretPoint(i, _))) = pt_gui.drag_lollipop {
-                                maybe_turret_offset = pt_gui.model.get_total_subobj_offset(pt_gui.model.turrets[i].gun_obj);
+                                maybe_turret_offset = pt_gui.model.get_total_submodel_offset(pt_gui.model.turrets[i].gun_model);
                             }
 
                             let modifiers = egui.egui_ctx().input(|input| input.modifiers);
@@ -1065,29 +1068,29 @@ fn main() {
 
                     let light_vec = glm::vec3(0.5, 1.0, -1.0);
 
-                    let displayed_subobjects =
-                        get_list_of_display_subobjects(model, pt_gui.ui_state.tree_view_selection, pt_gui.ui_state.last_selected_subobj);
+                    let displayed_submodels =
+                        get_list_of_display_submodels(model, pt_gui.ui_state.tree_view_selection, pt_gui.ui_state.last_selected_smodel);
 
-                    // draw the actual subobjects of the model
-                    for (i, buffer_objs) in pt_gui.model.buffer_objects.iter().enumerate() {
-                        let id = ObjectId(i as u32);
+                    // draw the actual submodels of the model
+                    for (i, buffer_meshes) in pt_gui.model.buffer_meshes.iter().enumerate() {
+                        let id = SubmodelId(i as u32);
                         // only render if its currently being displayed
-                        if displayed_subobjects.0.get(i).is_some_and(|val| *val) {
-                            let mut mat = pt_gui.model.subobject_transform_matrix[id];
-                            mat.append_translation_mut(&pt_gui.model.get_total_subobj_offset(id).into());
+                        if displayed_submodels.0.get(i).is_some_and(|val| *val) {
+                            let mut mat = pt_gui.model.submodel_transform_matrix[id];
+                            mat.append_translation_mut(&pt_gui.model.get_total_submodel_offset(id).into());
 
                             let matrix = view_mat * mat;
                             let norm_matrix: [[f32; 3]; 3] = glm::mat4_to_mat3(&matrix).try_inverse().unwrap().transpose().into();
                             let vert_matrix: [[f32; 4]; 4] = (perspective_matrix * matrix).into();
 
-                            for buffer_obj in &buffer_objs.buffers {
+                            for buffer_mesh in &buffer_meshes.buffers {
                                 let indices = if pt_gui.display_mode == DisplayMode::Wireframe {
-                                    buffer_obj.wireframe_indices.as_ref().unwrap_or(&buffer_obj.indices)
+                                    buffer_mesh.wireframe_indices.as_ref().unwrap_or(&buffer_mesh.indices)
                                 } else {
-                                    &buffer_obj.indices
+                                    &buffer_mesh.indices
                                 };
 
-                                if let Some(texture) = buffer_obj
+                                if let Some(texture) = buffer_mesh
                                     .texture_id
                                     // if the buffer has a tex id assigned...
                                     .filter(|_| pt_gui.display_mode == DisplayMode::Textured)
@@ -1103,13 +1106,13 @@ fn main() {
                                         dark_color: dark_color,
                                         light_color: light_color,
                                         tint_color: [0.0, 0.0, 1.0f32],
-                                        tint_val: buffer_obj.tint_val,
+                                        tint_val: buffer_mesh.tint_val,
                                         tex: texture,
                                     };
 
                                     target
                                         .draw(
-                                            (&buffer_obj.vertices, &buffer_obj.normals),
+                                            (&buffer_mesh.vertices, &buffer_mesh.normals),
                                             indices,
                                             &pt_gui.graphics.textured_material_shader,
                                             &uniforms,
@@ -1125,12 +1128,12 @@ fn main() {
                                         dark_color: dark_color,
                                         light_color: light_color,
                                         tint_color: [0.0, 0.0, 1.0f32],
-                                        tint_val: buffer_obj.tint_val,
+                                        tint_val: buffer_mesh.tint_val,
                                     };
 
                                     target
                                         .draw(
-                                            (&buffer_obj.vertices, &buffer_obj.normals),
+                                            (&buffer_mesh.vertices, &buffer_mesh.normals),
                                             indices,
                                             &pt_gui.graphics.default_material_shader,
                                             &uniforms,
@@ -1249,9 +1252,9 @@ fn main() {
                         }
                     }
 
-                    let mut obj_id = None; // None also indicates the header being possibly selected
-                    if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = pt_gui.tree_view_selection {
-                        obj_id = Some(id);
+                    let mut model_id = None; // None also indicates the header being possibly selected
+                    if let TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) = pt_gui.tree_view_selection {
+                        model_id = Some(id);
 
                         //      DEBUG - Draw BSP node bounding boxes
                         //      This is quite useful but incredibly ineffcient
@@ -1288,15 +1291,15 @@ fn main() {
 
                     // draw wireframe bounding boxes
                     if pt_gui.display_bbox {
-                        let bbox = if let Some(id) = obj_id {
-                            &pt_gui.model.sub_objects[id].bbox
+                        let bbox = if let Some(id) = model_id {
+                            &pt_gui.model.submodels[id].bbox
                         } else {
                             &pt_gui.model.header.bbox
                         };
 
                         let mut mat = glm::scaling(&(bbox.max - bbox.min).into());
-                        let offset = if let Some(id) = obj_id {
-                            pt_gui.model.get_total_subobj_offset(id)
+                        let offset = if let Some(id) = model_id {
+                            pt_gui.model.get_total_submodel_offset(id)
                         } else {
                             Vec3d::ZERO
                         };
@@ -1323,8 +1326,8 @@ fn main() {
                     // draw wireframe 'sphere'
                     if pt_gui.display_radius {
                         for i in 0..3 {
-                            let rad = if let Some(id) = obj_id {
-                                pt_gui.model.sub_objects[id].radius
+                            let rad = if let Some(id) = model_id {
+                                pt_gui.model.submodels[id].radius
                             } else {
                                 pt_gui.model.header.max_radius
                             };
@@ -1336,8 +1339,8 @@ fn main() {
                                 mat *= glm::rotation(std::f32::consts::FRAC_PI_2, &glm::vec3(1.0, 0.0, 0.0));
                             }
 
-                            let offset = if let Some(id) = obj_id {
-                                pt_gui.model.get_total_subobj_offset(id)
+                            let offset = if let Some(id) = model_id {
+                                pt_gui.model.get_total_submodel_offset(id)
                             } else {
                                 Vec3d::ZERO
                             };
@@ -1425,10 +1428,10 @@ fn main() {
                             .unwrap();
                     }
 
-                    // don't display lollipops if you're in header or subobjects, unless display_origin is on, since that's the only lollipop they have
+                    // don't display lollipops if you're in header or submodels, unless display_origin is on, since that's the only lollipop they have
 
                     let display_lollipops = (!matches!(pt_gui.ui_state.tree_view_selection, TreeValue::Header)
-                        && !matches!(pt_gui.ui_state.tree_view_selection, TreeValue::SubObjects(_)))
+                        && !matches!(pt_gui.ui_state.tree_view_selection, TreeValue::Submodels(_)))
                         || pt_gui.display_origin
                         || pt_gui.display_uvec_fvec;
 
@@ -1526,18 +1529,18 @@ fn main() {
                     }
 
                     // draw the turret fov angular frustum thing
-                    if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = pt_gui.tree_view_selection {
-                        if let Some(val) = properties_get_field(&model.sub_objects[id].properties, "$fov").and_then(|str| str.parse::<f32>().ok()) {
-                            let max_fov = properties_get_field(&model.sub_objects[id].properties, "$max_fov")
+                    if let TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) = pt_gui.tree_view_selection {
+                        if let Some(val) = properties_get_field(&model.submodels[id].properties, "$fov").and_then(|str| str.parse::<f32>().ok()) {
+                            let max_fov = properties_get_field(&model.submodels[id].properties, "$max_fov")
                                 .and_then(|str| str.parse::<f32>().ok())
                                 .unwrap_or(90.0);
-                            let base_fov = properties_get_field(&model.sub_objects[id].properties, "$base_fov")
+                            let base_fov = properties_get_field(&model.submodels[id].properties, "$base_fov")
                                 .and_then(|str| str.parse::<f32>().ok())
                                 .unwrap_or(360.0);
 
-                            if let Some((turret_idx, _)) = pt_gui.model.turrets.iter().enumerate().find(|(_, turret)| turret.base_obj == id) {
+                            if let Some((turret_idx, _)) = pt_gui.model.turrets.iter().enumerate().find(|(_, turret)| turret.base_model == id) {
                                 let mut turret_mat = pt_gui.model.turret_matrix(turret_idx);
-                                let offset = pt_gui.model.get_total_subobj_offset(id);
+                                let offset = pt_gui.model.get_total_submodel_offset(id);
                                 turret_mat.append_translation_mut(&offset.into());
                                 let vert_matrix: [[f32; 4]; 4] = (perspective_matrix * view_mat * turret_mat).into();
                                 let uniforms = glium::uniform! {
@@ -1628,48 +1631,48 @@ fn main() {
 
 // based on the current selection which submodels should be displayed
 // TODO show destroyed models
-fn get_list_of_display_subobjects(model: &Model, tree_selection: TreeValue, last_selected_subobj: Option<ObjectId>) -> ObjVec<bool> {
-    let mut out = ObjVec(vec![false; model.sub_objects.len()]);
+fn get_list_of_display_submodels(model: &Model, tree_selection: TreeValue, last_selected_smodel: Option<SubmodelId>) -> SubmodelVec<bool> {
+    let mut out = SubmodelVec(vec![false; model.submodels.len()]);
 
-    if model.sub_objects.is_empty() {
+    if model.submodels.is_empty() {
         return out;
     }
 
     if let TreeValue::Insignia(InsigniaTreeValue::Insignia(idx)) = tree_selection {
         // show the LOD objects according to the detail level of the currently selected insignia
-        for (i, sub_object) in model.sub_objects.iter().enumerate() {
-            out.0[i] = model.is_obj_id_ancestor(sub_object.obj_id, model.header.detail_levels[model.insignias[idx].detail_level as usize])
-                && !sub_object.is_destroyed_model();
+        for (i, submodel) in model.submodels.iter().enumerate() {
+            out.0[i] = model.is_model_id_ancestor(submodel.id, model.header.detail_levels[model.insignias[idx].detail_level as usize])
+                && !submodel.is_destroyed_model();
         }
-    } else if let Some(last_selected_subobj) = last_selected_subobj {
-        //find the top level parent of the currently subobject
-        let mut top_level_parent = last_selected_subobj;
-        while let Some(id) = model.sub_objects[top_level_parent].parent() {
+    } else if let Some(id) = last_selected_smodel {
+        //find the top level parent of the currently submodel
+        let mut top_level_parent = id;
+        while let Some(id) = model.submodels[top_level_parent].parent() {
             top_level_parent = id;
         }
 
-        let displaying_destroyed_models = model.sub_objects[last_selected_subobj].is_destroyed_model();
+        let displaying_destroyed_models = model.submodels[id].is_destroyed_model();
 
-        model.do_for_recursive_subobj_children(top_level_parent, &mut |subobj| {
-            if let Some(id) = subobj.parent() {
-                let has_a_destroyed_version = subobj.name_links.iter().any(|link| matches!(link, NameLink::DestroyedVersion(_)));
-                let parent = &model.sub_objects[id];
+        model.do_for_recursive_smodel_children(top_level_parent, &mut |smodel| {
+            if let Some(id) = smodel.parent() {
+                let has_a_destroyed_version = smodel.name_links.iter().any(|link| matches!(link, NameLink::DestroyedVersion(_)));
+                let parent = &model.submodels[id];
                 let parent_has_a_destroyed_version = parent.name_links.iter().any(|link| matches!(link, NameLink::DestroyedVersion(_)));
 
                 if (!parent_has_a_destroyed_version || (displaying_destroyed_models == parent.is_destroyed_model()))
-                    && (!has_a_destroyed_version || (displaying_destroyed_models == subobj.is_destroyed_model()))
+                    && (!has_a_destroyed_version || (displaying_destroyed_models == smodel.is_destroyed_model()))
                 {
-                    out[subobj.obj_id] = true;
+                    out[smodel.id] = true;
                 }
             } else {
-                out[subobj.obj_id] = true;
+                out[smodel.id] = true;
             }
         });
 
         // if they have debris selected show all the debris
-        if model.sub_objects[last_selected_subobj].is_debris_model {
-            for (i, sub_object) in model.sub_objects.iter().enumerate() {
-                out.0[i] = sub_object.is_debris_model;
+        if model.submodels[id].is_debris_model {
+            for (i, submodel) in model.submodels.iter().enumerate() {
+                out.0[i] = submodel.is_debris_model;
             }
         }
     }
@@ -1749,7 +1752,7 @@ impl PofToolsGui {
             TreeValue::Turrets(_) => {
                 for (i, turret) in self.model.turrets.iter().enumerate() {
                     for (j, point) in turret.fire_points.iter().enumerate() {
-                        let point = *point + self.model.get_total_subobj_offset(turret.gun_obj);
+                        let point = *point + self.model.get_total_submodel_offset(turret.gun_model);
                         proximity_test(point, TreeValue::Turrets(TurretTreeValue::TurretPoint(i, j)));
                     }
                 }
@@ -1773,7 +1776,7 @@ impl PofToolsGui {
     }
 
     fn maybe_recalculate_3d_helpers(&mut self, display: &Display<WindowSurface>) {
-        if self.model.buffer_objects.is_empty() {
+        if self.model.buffer_meshes.is_empty() {
             return;
         }
 
@@ -1782,7 +1785,7 @@ impl PofToolsGui {
         //     return;
         // }
 
-        for buffers in self.model.buffer_objects.iter_mut() {
+        for buffers in self.model.buffer_meshes.iter_mut() {
             for buffer in &mut buffers.buffers {
                 buffer.tint_val = 0.0;
             }
@@ -1802,18 +1805,18 @@ impl PofToolsGui {
         // push the according lollipop positions/normals based on the points positions/normals
         // push into 3 separate vectors, for 3 separate colors depending on selection state
         match self.ui_state.tree_view_selection {
-            TreeValue::SubObjects(SubObjectTreeValue::SubObject(obj_id)) => {
-                for (i, buffers) in self.model.buffer_objects.iter_mut().enumerate() {
-                    if i as u32 == obj_id.0 {
+            TreeValue::Submodels(SubmodelTreeValue::Submodel(model_id)) => {
+                for (i, buffers) in self.model.buffer_meshes.iter_mut().enumerate() {
+                    if i as u32 == model_id.0 {
                         for buffer in &mut buffers.buffers {
                             buffer.tint_val = 0.2;
                         }
                     }
                 }
 
-                let radius = model.sub_objects[obj_id].radius;
+                let radius = model.submodels[model_id].radius;
                 let size = 0.05 * radius;
-                let pos = model.get_total_subobj_offset(obj_id);
+                let pos = model.get_total_submodel_offset(model_id);
 
                 let mut ball_origin = GlLollipopsBuilder::new(LOLLIPOP_SELECTED_POINT_COLOR);
                 // Origin lollipop (ball only)
@@ -1821,7 +1824,7 @@ impl PofToolsGui {
                 let ball_origin = ball_origin.finish(display);
                 self.lollipops = vec![ball_origin];
 
-                if let Some((uvec, fvec)) = model.sub_objects[obj_id].uvec_fvec() {
+                if let Some((uvec, fvec)) = model.submodels[model_id].uvec_fvec() {
                     // Set up arrowhead sticks
                     let stick_length = 2. * radius;
                     // Blue lollipop (stick only) for uvec
@@ -1854,7 +1857,7 @@ impl PofToolsGui {
                 }
             }
             TreeValue::Textures(TextureTreeValue::Texture(tex)) => {
-                for buffers in self.model.buffer_objects.iter_mut() {
+                for buffers in self.model.buffer_meshes.iter_mut() {
                     for buffer in &mut buffers.buffers {
                         if buffer.texture_id.map(|id| self.model.texture_map[&id]) == Some(tex) {
                             buffer.tint_val = 0.3;
@@ -2122,7 +2125,7 @@ impl PofToolsGui {
                     &COLORS,
                     display,
                     model.turrets.iter().enumerate().flat_map(|(turret_idx, turret)| {
-                        let offset = self.model.get_total_subobj_offset(turret.gun_obj);
+                        let offset = self.model.get_total_submodel_offset(turret.gun_model);
                         turret.fire_points.iter().enumerate().map(move |(point_idx, fire_point)| {
                             let position = *fire_point + offset;
                             let normal = turret.normal.0 * size * 2.0;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,7 +4,7 @@ use glium::{
     texture::{RawImage2d, SrgbTexture2d},
     Display,
 };
-use pof::{properties_get_field, Error, ObjVec, Set, SubObject, TextureId, Vec3d, Version, Warning, WeaponHardpoint};
+use pof::{properties_get_field, Error, Set, Submodel, SubmodelVec, TextureId, Vec3d, Version, Warning, WeaponHardpoint};
 use std::{
     collections::HashMap,
     f32::consts::{FRAC_PI_2, PI},
@@ -14,7 +14,7 @@ use std::{
 use winit::window::Window;
 
 use eframe::egui::{self, Button, TextStyle, Ui};
-use pof::ObjectId;
+use pof::SubmodelId;
 
 use crate::{
     ui_import::ImportWindow, ui_properties_panel::PropertiesPanel, GlArrowhead, GlBufferedInsignia, GlBufferedShield, GlLollipops, Graphics, Model,
@@ -24,7 +24,7 @@ use crate::{
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, PartialOrd, Ord)]
 pub enum TreeValue {
     Header,
-    SubObjects(SubObjectTreeValue),
+    Submodels(SubmodelTreeValue),
     Textures(TextureTreeValue),
     Weapons(WeaponTreeValue),
     DockingBays(DockingTreeValue),
@@ -43,7 +43,7 @@ impl std::fmt::Display for TreeValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TreeValue::Header => write!(f, "Header"),
-            TreeValue::SubObjects(selection) => write!(f, "Subobjects - {}", selection),
+            TreeValue::Submodels(selection) => write!(f, "Submodels - {}", selection),
             TreeValue::Textures(selection) => write!(f, "Textures - {}", selection),
             TreeValue::Weapons(selection) => write!(f, "Weapons - {}", selection),
             TreeValue::DockingBays(selection) => write!(f, "DockingBays - {}", selection),
@@ -97,14 +97,14 @@ impl TreeValue {
     // returns what, if any, tree_value best corresponds to a given error
     fn from_error(error: &Error) -> Option<TreeValue> {
         match error {
-            Error::InvalidTurretGunSubobject(idx) => Some(TreeValue::Turrets(TurretTreeValue::Turret(*idx))),
-            Error::TooManyDebrisObjects => None,
-            Error::DetailObjWithParent(id) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(*id))),
-            Error::DetailAndDebrisObj(id) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(*id))),
-            Error::TooManyVerts(id) | Error::TooManyNorms(id) | Error::UnnamedSubObject(id) => {
-                Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(*id)))
+            Error::InvalidTurretGunSubmodel(idx) => Some(TreeValue::Turrets(TurretTreeValue::Turret(*idx))),
+            Error::TooManyDebrisModels => None,
+            Error::DetailModelWithParent(id) => Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(*id))),
+            Error::DetailAndDebrisModel(id) => Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(*id))),
+            Error::TooManyVerts(id) | Error::TooManyNorms(id) | Error::UnnamedSubmodel(id) => {
+                Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(*id)))
             }
-            Error::DuplicateSubobjectName(_) => None,
+            Error::DuplicateSubmodelName(_) => None,
         }
     }
 
@@ -114,10 +114,10 @@ impl TreeValue {
             Warning::RadiusTooSmall(None) => Some(TreeValue::Header),
             Warning::BBoxTooSmall(None) => Some(TreeValue::Header),
             Warning::InvertedBBox(None) => Some(TreeValue::Header),
-            Warning::RadiusTooSmall(Some(id)) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(*id))),
-            Warning::BBoxTooSmall(Some(id)) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(*id))),
-            Warning::InvertedBBox(Some(id)) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(*id))),
-            Warning::SubObjectTranslationInvalidVersion(id) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(*id))),
+            Warning::RadiusTooSmall(Some(id)) => Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(*id))),
+            Warning::BBoxTooSmall(Some(id)) => Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(*id))),
+            Warning::InvertedBBox(Some(id)) => Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(*id))),
+            Warning::SubmodelTranslationInvalidVersion(id) => Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(*id))),
             Warning::UntexturedPolygons => Some(TreeValue::Textures(TextureTreeValue::tex(model.untextured_idx))),
             Warning::DockingBayWithoutPath(idx) => Some(TreeValue::DockingBays(DockingTreeValue::Bay(*idx))),
             Warning::ThrusterPropertiesInvalidVersion(idx) => Some(TreeValue::Thrusters(ThrusterTreeValue::Bank(*idx))),
@@ -136,15 +136,15 @@ impl TreeValue {
             Warning::TooManyTextures => Some(TreeValue::Textures(TextureTreeValue::Header)),
             Warning::PathNameTooLong(idx) => Some(TreeValue::Paths(PathTreeValue::Path(*idx))),
             Warning::SpecialPointNameTooLong(idx) => Some(TreeValue::SpecialPoints(SpecialPointTreeValue::Point(*idx))),
-            Warning::SubObjectNameTooLong(id) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(*id))),
+            Warning::SubmodelNameTooLong(id) => Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(*id))),
             Warning::DockingBayNameTooLong(idx) => Some(TreeValue::DockingBays(DockingTreeValue::Bay(*idx))),
-            Warning::SubObjectPropertiesTooLong(id) => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(*id))),
+            Warning::SubmodelPropertiesTooLong(id) => Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(*id))),
             Warning::ThrusterPropertiesTooLong(idx) => Some(TreeValue::Thrusters(ThrusterTreeValue::Bank(*idx))),
             Warning::DockingBayPropertiesTooLong(idx) => Some(TreeValue::DockingBays(DockingTreeValue::Bay(*idx))),
             Warning::GlowBankPropertiesTooLong(idx) => Some(TreeValue::Glows(GlowTreeValue::Bank(*idx))),
             Warning::SpecialPointPropertiesTooLong(idx) => Some(TreeValue::SpecialPoints(SpecialPointTreeValue::Point(*idx))),
             Warning::InvalidDockParentSubmodel(idx) => Some(TreeValue::DockingBays(DockingTreeValue::Bay(*idx))),
-            Warning::Detail0NonZeroOffset => Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(model.header.detail_levels[0]))),
+            Warning::Detail0NonZeroOffset => Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(model.header.detail_levels[0]))),
         }
     }
 
@@ -153,7 +153,7 @@ impl TreeValue {
             return false;
         }
         match (self, maybe_descendant) {
-            (TreeValue::SubObjects(SubObjectTreeValue::Header), TreeValue::SubObjects(_)) => true,
+            (TreeValue::Submodels(SubmodelTreeValue::Header), TreeValue::Submodels(_)) => true,
             (TreeValue::Textures(TextureTreeValue::Header), TreeValue::Textures(_)) => true,
             (TreeValue::Weapons(WeaponTreeValue::Header), TreeValue::Weapons(_)) => true,
             (TreeValue::Weapons(WeaponTreeValue::PriHeader), TreeValue::Weapons(WeaponTreeValue::PriBank(_))) => true,
@@ -463,23 +463,23 @@ impl ThrusterTreeValue {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
-pub enum SubObjectTreeValue {
+pub enum SubmodelTreeValue {
     Header,
-    SubObject(ObjectId),
+    Submodel(SubmodelId),
 }
 
-impl std::fmt::Display for SubObjectTreeValue {
+impl std::fmt::Display for SubmodelTreeValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SubObjectTreeValue::Header => write!(f, "Header"),
-            SubObjectTreeValue::SubObject(idx) => write!(f, "SubObject {}", idx.0 + 1),
+            SubmodelTreeValue::Header => write!(f, "Header"),
+            SubmodelTreeValue::Submodel(idx) => write!(f, "Submodel {}", idx.0 + 1),
         }
     }
 }
-impl SubObjectTreeValue {
-    pub fn subobj(id: Option<ObjectId>) -> Self {
+impl SubmodelTreeValue {
+    pub fn smodel(id: Option<SubmodelId>) -> Self {
         match id {
-            Some(id) => Self::SubObject(id),
+            Some(id) => Self::Submodel(id),
             None => Self::Header,
         }
     }
@@ -508,7 +508,7 @@ pub struct UiState {
     pub tree_view_force_open: Option<TreeValue>,
     pub viewport_3d_dirty: bool,
     pub properties_panel_dirty: bool,
-    pub last_selected_subobj: Option<ObjectId>,
+    pub last_selected_smodel: Option<SubmodelId>,
     pub properties_panel: PropertiesPanel,
     pub import_window: ImportWindow,
     pub display_radius: bool,
@@ -516,6 +516,7 @@ pub struct UiState {
     pub display_origin: bool,
     pub display_uvec_fvec: bool,
     pub move_only_offset: bool,
+    pub auto_gen_paths_confirm: bool,
 }
 
 pub(crate) struct PofToolsGui {
@@ -555,8 +556,6 @@ pub(crate) struct PofToolsGui {
     pub buffer_insignias: Vec<GlBufferedInsignia>,          // the insignias, similar to the above
     pub lollipops: Vec<GlLollipops>, // the current set of lollipops being being drawn, grouped by color, and recalculated with viewport_3d_dirty above
     pub arrowheads: Vec<GlArrowhead>, // The arrowheads to draw
-
-    pub auto_gen_paths_confirm: bool,
 }
 impl std::ops::Deref for PofToolsGui {
     type Target = UiState;
@@ -576,8 +575,9 @@ impl PofToolsGui {
             model: Box::new(Model {
                 pof_model: pof::Model::default(),
                 texture_map: HashMap::new(),
-                subobject_transform_matrix: ObjVec::default(),
-                buffer_objects: ObjVec::default(),
+                submodel_transform_matrix: SubmodelVec::default(),
+                submodel_duplicated: SubmodelVec::default(),
+                buffer_meshes: SubmodelVec::default(),
             }),
             model_loading_thread: Default::default(),
             texture_loading_thread: Default::default(),
@@ -617,7 +617,6 @@ impl PofToolsGui {
             drag_axis: DragAxis::YZ,
             actually_dragging: false,
             graphics: Graphics::init(display),
-            auto_gen_paths_confirm: false,
         }
     }
 
@@ -640,11 +639,11 @@ impl UiState {
             RichText::new(this_name)
         };
         for error in &model.errors {
-            if let Error::DuplicateSubobjectName(duped_name) = error {
+            if let Error::DuplicateSubmodelName(duped_name) = error {
                 match tree_value {
-                    TreeValue::SubObjects(SubObjectTreeValue::Header) => return text.color(ERROR_RED),
-                    TreeValue::SubObjects(SubObjectTreeValue::SubObject(obj_id)) => {
-                        if model.sub_objects[obj_id].name == *duped_name {
+                    TreeValue::Submodels(SubmodelTreeValue::Header) => return text.color(ERROR_RED),
+                    TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) => {
+                        if model.submodels[id].name == *duped_name {
                             return text.color(ERROR_RED);
                         }
                     }
@@ -675,9 +674,9 @@ impl UiState {
             }
         }
 
-        if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(selected_id)) = self.tree_view_selection {
-            if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(this_id)) = tree_value {
-                for link in &model.sub_objects[this_id].name_links {
+        if let TreeValue::Submodels(SubmodelTreeValue::Submodel(selected_id)) = self.tree_view_selection {
+            if let TreeValue::Submodels(SubmodelTreeValue::Submodel(this_id)) = tree_value {
+                for link in &model.submodels[this_id].name_links {
                     match *link {
                         pof::NameLink::DestroyedVersion(id) | pof::NameLink::DestroyedVersionOf(id) if id == selected_id => {
                             return text.color(Color32::LIGHT_RED)
@@ -703,11 +702,11 @@ impl UiState {
 
             info!("Switched to Treeview - {}", self.tree_view_selection);
 
-            // maybe update ast selected object
-            if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = self.tree_view_selection {
-                self.last_selected_subobj = Some(id);
-            } else if let TreeValue::SubObjects(SubObjectTreeValue::Header) | TreeValue::Header = self.tree_view_selection {
-                self.last_selected_subobj = model.header.detail_levels.first().copied();
+            // maybe update last selected model
+            if let TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) = self.tree_view_selection {
+                self.last_selected_smodel = Some(id);
+            } else if let TreeValue::Submodels(SubmodelTreeValue::Header) | TreeValue::Header = self.tree_view_selection {
+                self.last_selected_smodel = model.header.detail_levels.first().copied();
             }
         }
     }
@@ -736,11 +735,11 @@ impl UiState {
 
                     info!("Switched to Treeview - {}", self.tree_view_selection);
 
-                    // maybe update last selected object
-                    if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = self.tree_view_selection {
-                        self.last_selected_subobj = Some(id);
-                    } else if let TreeValue::SubObjects(SubObjectTreeValue::Header) | TreeValue::Header = self.tree_view_selection {
-                        self.last_selected_subobj = model.header.detail_levels.first().copied();
+                    // maybe update last selected model
+                    if let TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) = self.tree_view_selection {
+                        self.last_selected_smodel = Some(id);
+                    } else if let TreeValue::Submodels(SubmodelTreeValue::Header) | TreeValue::Header = self.tree_view_selection {
+                        self.last_selected_smodel = model.header.detail_levels.first().copied();
                     }
                 }
             })
@@ -751,8 +750,8 @@ impl UiState {
         self.tree_view_selection = new_tree_val;
         self.tree_view_force_open = Some(new_tree_val);
         self.viewport_3d_dirty = true;
-        if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = new_tree_val {
-            self.last_selected_subobj = Some(id);
+        if let TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) = new_tree_val {
+            self.last_selected_smodel = Some(id);
         }
     }
 }
@@ -792,7 +791,7 @@ pub fn model_action(undo_history: &mut undo::History<UndoAction>, model: &mut Mo
 impl PofToolsGui {
     pub fn sanitize_ui_state(&mut self) {
         let (idx, len) = match self.tree_view_selection {
-            TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) => (id.0 as usize, self.model.sub_objects.len()),
+            TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) => (id.0 as usize, self.model.submodels.len()),
             TreeValue::Textures(TextureTreeValue::Texture(id)) => (id.0 as usize, self.model.textures.len()),
             TreeValue::Weapons(WeaponTreeValue::PriBank(idx)) => (idx, self.model.primary_weps.len()),
             TreeValue::Weapons(WeaponTreeValue::PriBankPoint(bank_idx, idx)) => (idx, self.model.primary_weps[bank_idx].len()),
@@ -824,8 +823,8 @@ impl PofToolsGui {
         };
 
         self.tree_view_selection = match self.tree_view_selection {
-            TreeValue::SubObjects(SubObjectTreeValue::SubObject(_)) => {
-                TreeValue::SubObjects(SubObjectTreeValue::subobj(new_idx.map(|idx| ObjectId(idx as u32))))
+            TreeValue::Submodels(SubmodelTreeValue::Submodel(_)) => {
+                TreeValue::Submodels(SubmodelTreeValue::smodel(new_idx.map(|idx| SubmodelId(idx as u32))))
             }
             TreeValue::Textures(TextureTreeValue::Texture(_)) => TreeValue::Textures(TextureTreeValue::tex(new_idx.map(|idx| TextureId(idx as u32)))),
             TreeValue::Weapons(WeaponTreeValue::PriBank(_)) => TreeValue::Weapons(WeaponTreeValue::bank(true, new_idx)),
@@ -1029,66 +1028,66 @@ impl PofToolsGui {
                         let mut first_warning = true;
                         for error in &self.model.errors {
                             let str = match error {
-                                Error::InvalidTurretGunSubobject(turret_num) => {
-                                    format!("⊗ {} has an invalid gun object", self.model.sub_objects[self.model.turrets[*turret_num].base_obj].name)
+                                Error::InvalidTurretGunSubmodel(turret_num) => {
+                                    format!("⊗ {} has an invalid gun submodel", self.model.submodels[self.model.turrets[*turret_num].base_model].name)
                                 }
-                                Error::TooManyDebrisObjects => {
+                                Error::TooManyDebrisModels => {
                                     let mut num_debris = 0;
-                                    for sobj in &self.model.sub_objects {
-                                        if sobj.is_debris_model {
+                                    for smodel in &self.model.submodels {
+                                        if smodel.is_debris_model {
                                             num_debris += 1;
                                         }
                                     }
-                                    format!("⊗ This model has too many debris objects ({}/{})", num_debris, pof::MAX_DEBRIS_OBJECTS)
+                                    format!("⊗ This model has too many debris submodels ({}/{})", num_debris, pof::MAX_DEBRIS_MODELS)
                                 }
-                                Error::DetailObjWithParent(id) => {
+                                Error::DetailModelWithParent(id) => {
                                     format!(
-                                        "⊗ Detail {} object ({}) must be at the top of the hierarchy (no object parent)",
+                                        "⊗ Detail {} submodel ({}) must be at the top of the hierarchy (no submodel parent)",
                                         self.model.header.detail_levels.iter().position(|detail_id| detail_id == id).unwrap(),
-                                        self.model.sub_objects[*id].name,
+                                        self.model.submodels[*id].name,
                                     )
                                 }
-                                Error::DetailAndDebrisObj(id) => {
+                                Error::DetailAndDebrisModel(id) => {
                                     format!(
-                                        "⊗ Detail {} object ({}) cannot also be a debris object",
+                                        "⊗ Detail {} submodel ({}) cannot also be a debris submodel",
                                         self.model.header.detail_levels.iter().position(|detail_id| detail_id == id).unwrap(),
-                                        self.model.sub_objects[*id].name,
+                                        self.model.submodels[*id].name,
                                     )
                                 }
                                 Error::TooManyVerts(id) => {
                                     format!(
-                                        "⊗ Subobject {} has more than the {} vertices supported by the currently selected pof version",
-                                        self.model.sub_objects[*id].name,
-                                        self.model.max_verts_norms_per_subobj(),
+                                        "⊗ Submodel {} has more than the {} vertices supported by the currently selected pof version",
+                                        self.model.submodels[*id].name,
+                                        self.model.max_verts_norms_per_submodel(),
                                     )
                                 }
                                 Error::TooManyNorms(id) => {
                                     format!(
-                                        "⊗ Subobject {} has more than the {} normals supported by the currently selected pof version",
-                                        self.model.sub_objects[*id].name,
-                                        self.model.max_verts_norms_per_subobj(),
+                                        "⊗ Submodel {} has more than the {} normals supported by the currently selected pof version",
+                                        self.model.submodels[*id].name,
+                                        self.model.max_verts_norms_per_submodel(),
                                     )
                                 }
-                                Error::UnnamedSubObject(id) => {
-                                    format!("⊗ Subobject id {:?} requires a name", id)
+                                Error::UnnamedSubmodel(id) => {
+                                    format!("⊗ Submodel id {:?} requires a name", id)
                                 }
-                                Error::DuplicateSubobjectName(name) => {
-                                    format!("⊗ More than one subobject shares the name '{}'", name)
+                                Error::DuplicateSubmodelName(name) => {
+                                    format!("⊗ More than one submodel shares the name '{}'", name)
                                 }
                             };
 
                             let text = RichText::new(str).text_style(TextStyle::Button).color(ERROR_RED);
                             ui.horizontal(|ui| {
-                                if let Error::DuplicateSubobjectName(duped_name) = error {
+                                if let Error::DuplicateSubmodelName(duped_name) = error {
                                     // do some special stuff for dupe names, so we can click and scroll through the list
                                     if ui.selectable_label(false, text).clicked() {
                                         let mut fallback = true;
-                                        if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = self.tree_view_selection {
-                                            if self.model.sub_objects[id].name == *duped_name {
-                                                // slicing is ugly on an objvec...
-                                                for subobj in self.model.sub_objects.0[((id.0 + 1) as usize)..].iter() {
-                                                    if subobj.name == *duped_name {
-                                                        new_tree_val = Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(subobj.obj_id)));
+                                        if let TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) = self.tree_view_selection {
+                                            if self.model.submodels[id].name == *duped_name {
+                                                // slicing is ugly on an submodelvec...
+                                                for smodel in self.model.submodels.0[((id.0 + 1) as usize)..].iter() {
+                                                    if smodel.name == *duped_name {
+                                                        new_tree_val = Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(smodel.id)));
                                                         fallback = false;
                                                         break;
                                                     }
@@ -1098,8 +1097,8 @@ impl PofToolsGui {
 
                                         if fallback {
                                             // in all other cases go to the first one
-                                            let first = self.model.sub_objects.iter().find(|subobj| subobj.name == *duped_name).unwrap();
-                                            new_tree_val = Some(TreeValue::SubObjects(SubObjectTreeValue::SubObject(first.obj_id)));
+                                            let first = self.model.submodels.iter().find(|smodel| smodel.name == *duped_name).unwrap();
+                                            new_tree_val = Some(TreeValue::Submodels(SubmodelTreeValue::Submodel(first.id)));
                                         }
                                     }
                                 } else if let Some(tree_val) = TreeValue::from_error(error) {
@@ -1136,7 +1135,7 @@ impl PofToolsGui {
                         for warning in &self.model.warnings {
                             let str = match warning {
                                 Warning::InvertedBBox(id_opt) => {
-                                    format!("⚠ {}'s bounding box is inverted", id_opt.map_or("The header", |id| &self.model.sub_objects[id].name))
+                                    format!("⚠ {}'s bounding box is inverted", id_opt.map_or("The header", |id| &self.model.submodels[id].name))
                                 }
                                 Warning::DockingBayWithoutPath(bay_num) => {
                                     format!(
@@ -1155,10 +1154,10 @@ impl PofToolsGui {
                                         point + 1
                                     )
                                 }
-                                Warning::SubObjectTranslationInvalidVersion(id) => {
+                                Warning::SubmodelTranslationInvalidVersion(id) => {
                                     format!(
-                                        "⚠ Subobject {} has a translation axis defined, which the currently selected version does not support",
-                                        self.model.sub_objects[*id].name
+                                        "⚠ Submodel {} has a translation axis defined, which the currently selected version does not support",
+                                        self.model.submodels[*id].name
                                     )
                                 }
                                 Warning::UntexturedPolygons => {
@@ -1173,32 +1172,32 @@ impl PofToolsGui {
                                     format!("⚠ You cannot have more than {} textures.", pof::MAX_TEXTURES)
                                 }
                                 Warning::TooFewTurretFirePoints(idx) => {
-                                    format!("⚠ {} must have at least 1 fire point.", self.model.sub_objects[self.model.turrets[*idx].base_obj].name)
+                                    format!("⚠ {} must have at least 1 fire point.", self.model.submodels[self.model.turrets[*idx].base_model].name)
                                 }
                                 Warning::TooManyTurretFirePoints(idx) => {
                                     format!(
                                         "⚠ {} must have at most {} fire points.",
-                                        self.model.sub_objects[self.model.turrets[*idx].base_obj].name,
+                                        self.model.submodels[self.model.turrets[*idx].base_model].name,
                                         pof::MAX_TURRET_POINTS
                                     )
                                 }
                                 Warning::RadiusTooSmall(id_opt) => {
                                     format!(
                                         "⚠ {}'s radius does not encompass all of its geometry",
-                                        id_opt.map_or("The header", |id| &self.model.sub_objects[id].name)
+                                        id_opt.map_or("The header", |id| &self.model.submodels[id].name)
                                     )
                                 }
                                 Warning::BBoxTooSmall(id_opt) => {
                                     format!(
                                         "⚠ {}'s bounding box does not encompass all of its geometry",
-                                        id_opt.map_or("The header", |id| &self.model.sub_objects[id].name)
+                                        id_opt.map_or("The header", |id| &self.model.submodels[id].name)
                                     )
                                 }
                                 Warning::DuplicatePathName(duped_name) => {
                                     format!("⚠ More than one path shares the name '{}'", duped_name)
                                 }
                                 Warning::DuplicateDetailLevel(id) => {
-                                    format!("⚠ Subobject '{}' belongs to more than one detail level", self.model.sub_objects[*id].name)
+                                    format!("⚠ Submodel '{}' belongs to more than one detail level", self.model.submodels[*id].name)
                                 }
                                 Warning::InvalidDockParentSubmodel(idx) => {
                                     let dock_name = self.model.docking_bays[*idx]
@@ -1212,18 +1211,18 @@ impl PofToolsGui {
                                 }
                                 Warning::Detail0NonZeroOffset => {
                                     let id = self.model.header.detail_levels[0];
-                                    format!("⚠ Detail0 object '{}' should have a (0, 0, 0) offset.", self.model.sub_objects[id].name)
+                                    format!("⚠ Detail0 submodel '{}' should have a (0, 0, 0) offset.", self.model.submodels[id].name)
                                 }
                                 Warning::PathNameTooLong(_)
-                                | Warning::SubObjectNameTooLong(_)
+                                | Warning::SubmodelNameTooLong(_)
                                 | Warning::SpecialPointNameTooLong(_)
                                 | Warning::DockingBayNameTooLong(_) => {
                                     let field = match warning {
                                         Warning::PathNameTooLong(idx) => {
                                             format!("Path name '{}'", self.model.paths[*idx].name)
                                         }
-                                        Warning::SubObjectNameTooLong(id) => {
-                                            format!("Subobject name '{}'", self.model.sub_objects[*id].name)
+                                        Warning::SubmodelNameTooLong(id) => {
+                                            format!("Submodel name '{}'", self.model.submodels[*id].name)
                                         }
                                         Warning::SpecialPointNameTooLong(idx) => {
                                             format!("Special point name '{}'", self.model.special_points[*idx].name)
@@ -1237,7 +1236,7 @@ impl PofToolsGui {
                                 }
                                 Warning::GlowBankPropertiesTooLong(_)
                                 | Warning::ThrusterPropertiesTooLong(_)
-                                | Warning::SubObjectPropertiesTooLong(_)
+                                | Warning::SubmodelPropertiesTooLong(_)
                                 | Warning::DockingBayPropertiesTooLong(_)
                                 | Warning::SpecialPointPropertiesTooLong(_) => {
                                     let field = match warning {
@@ -1252,8 +1251,8 @@ impl PofToolsGui {
                                         Warning::ThrusterPropertiesTooLong(idx) => {
                                             format!("Thruster bank {} properties", idx + 1)
                                         }
-                                        Warning::SubObjectPropertiesTooLong(id) => {
-                                            format!("Subobject {} properties", self.model.sub_objects[*id].name)
+                                        Warning::SubmodelPropertiesTooLong(id) => {
+                                            format!("Submodel {} properties", self.model.submodels[*id].name)
                                         }
                                         Warning::DockingBayPropertiesTooLong(idx) => {
                                             format!("Docking bay {} properties", idx + 1)
@@ -1333,7 +1332,7 @@ impl PofToolsGui {
 
         // ==============================================================================================================
         // The 'tree view' is the section on the left of the UI which contains selections for the various kinds of things
-        // the user can edit, turrets, hardpoints, subobjects, etc
+        // the user can edit, turrets, hardpoints, submodels, etc
         // ==============================================================================================================
 
         egui::SidePanel::left("tree_view")
@@ -1344,26 +1343,33 @@ impl PofToolsGui {
                 egui::ScrollArea::vertical().auto_shrink([false, false]).show(ui, |ui| {
                     self.tree_selectable_item(ui, "Header", TreeValue::Header);
 
-                    let num_subobjs = self.model.sub_objects.len();
-                    let name = format!("SubObjects{}", if num_subobjs > 0 { format!(", {}", num_subobjs) } else { String::new() });
+                    let num_submodels = self.model.submodels.len();
+                    let name = format!(
+                        "Submodels{}",
+                        if num_submodels > 0 {
+                            format!(", {}", num_submodels)
+                        } else {
+                            String::new()
+                        }
+                    );
                     self.ui_state
-                        .tree_collapsing_item(&self.model, ui, &name, TreeValue::SubObjects(SubObjectTreeValue::Header), |ui_state, ui| {
-                            fn make_subobject_child_list(ui_state: &mut UiState, model: &Model, obj: &SubObject, ui: &mut Ui) {
-                                let selection = TreeValue::SubObjects(SubObjectTreeValue::SubObject(obj.obj_id));
-                                if obj.children().next().is_none() {
-                                    ui_state.tree_selectable_item(model, ui, &obj.name, selection);
+                        .tree_collapsing_item(&self.model, ui, &name, TreeValue::Submodels(SubmodelTreeValue::Header), |ui_state, ui| {
+                            fn make_submodel_child_list(ui_state: &mut UiState, model: &Model, smodel: &Submodel, ui: &mut Ui) {
+                                let selection = TreeValue::Submodels(SubmodelTreeValue::Submodel(smodel.id));
+                                if smodel.children().next().is_none() {
+                                    ui_state.tree_selectable_item(model, ui, &smodel.name, selection);
                                 } else {
-                                    ui_state.tree_collapsing_item(model, ui, &obj.name, selection, |ui_state, ui| {
-                                        for &i in obj.children() {
-                                            make_subobject_child_list(ui_state, model, &model.sub_objects[i], ui)
+                                    ui_state.tree_collapsing_item(model, ui, &smodel.name, selection, |ui_state, ui| {
+                                        for &i in smodel.children() {
+                                            make_submodel_child_list(ui_state, model, &model.submodels[i], ui)
                                         }
                                     });
                                 }
                             }
 
-                            for object in &self.model.sub_objects {
-                                if object.parent().is_none() {
-                                    make_subobject_child_list(ui_state, &self.model, object, ui);
+                            for submodel in &self.model.submodels {
+                                if submodel.parent().is_none() {
+                                    make_submodel_child_list(ui_state, &self.model, submodel, ui);
                                 }
                             }
                         });
@@ -1538,7 +1544,7 @@ impl PofToolsGui {
                                 ui_state.tree_collapsing_item(
                                     &self.model,
                                     ui,
-                                    &format!("{}, {}", self.model.sub_objects[turret.base_obj].name, turret.fire_points.len()),
+                                    &format!("{}, {}", self.model.submodels[turret.base_model].name, turret.fire_points.len()),
                                     TreeValue::Turrets(TurretTreeValue::Turret(i)),
                                     |ui_state, ui| {
                                         for j in 0..turret.fire_points.len() {
@@ -1609,8 +1615,8 @@ impl PofToolsGui {
                                     ui,
                                     &format!(
                                         "{} {}",
-                                        if let Some(id) = eye.attached_subobj {
-                                            &self.model.sub_objects[id].name
+                                        if let Some(id) = eye.attached_submodel {
+                                            &self.model.submodels[id].name
                                         } else {
                                             "(None)"
                                         },

--- a/src/ui_import.rs
+++ b/src/ui_import.rs
@@ -1,10 +1,10 @@
 use egui::{collapsing_header::CollapsingState, Button, Color32, Id, Response, RichText, TextEdit, TextStyle, Ui, WidgetText};
-use pof::{properties_delete_field, ObjectId, SubObject, TextureId};
+use pof::{properties_delete_field, Submodel, SubmodelId, TextureId};
 
 use crate::{
     start_loading_import_model,
     ui::{
-        DockingTreeValue, EyeTreeValue, GlowTreeValue, InsigniaTreeValue, PathTreeValue, PofToolsGui, SpecialPointTreeValue, SubObjectTreeValue,
+        DockingTreeValue, EyeTreeValue, GlowTreeValue, InsigniaTreeValue, PathTreeValue, PofToolsGui, SpecialPointTreeValue, SubmodelTreeValue,
         ThrusterTreeValue, TreeValue, TurretTreeValue, UiState, WeaponTreeValue, ERROR_RED, WARNING_YELLOW,
     },
     LoadingThread, Model,
@@ -27,7 +27,7 @@ enum SelectionType {
 
 #[derive(Default)]
 struct ImportOptions {
-    auto_select_subobj_children: bool,
+    auto_select_smodel_children: bool,
     auto_select_paths: bool,
     auto_select_turrets: bool,
 }
@@ -56,7 +56,7 @@ impl Default for ImportWindow {
             import_model_loading_thread: Default::default(),
             import_selection: BTreeSet::new(),
             import_options: ImportOptions {
-                auto_select_subobj_children: true,
+                auto_select_smodel_children: true,
                 auto_select_paths: true,
                 auto_select_turrets: true,
             },
@@ -77,7 +77,7 @@ impl UiState {
 
         window.show(ctx, |ui| {
             let selection = &self.import_window.import_selection;
-            let num_subobjects_selected = selection.iter().filter(|select| matches!(select, TreeValue::SubObjects(_))).count();
+            let num_submodels_selected = selection.iter().filter(|select| matches!(select, TreeValue::Submodels(_))).count();
             let num_pri_banks_selected = selection
                 .iter()
                 .filter(|select| matches!(select, TreeValue::Weapons(WeaponTreeValue::PriBank(_))))
@@ -105,8 +105,8 @@ impl UiState {
                     );
 
                     ui.checkbox(
-                        &mut self.import_window.import_options.auto_select_subobj_children,
-                        "Auto-select subobject children on subobject selection.",
+                        &mut self.import_window.import_options.auto_select_smodel_children,
+                        "Auto-select submodel children on submodel selection.",
                     );
                     ui.checkbox(&mut self.import_window.import_options.auto_select_paths, "Auto-select associated paths, if available.");
                     ui.checkbox(&mut self.import_window.import_options.auto_select_turrets, "Auto-select associated turret data, if available.");
@@ -177,27 +177,23 @@ impl UiState {
                             }
                         }
 
-                        if num_subobjects_selected > 0 {
-                            ui.label(format!(
-                                "{} SubObject{} selected.",
-                                num_subobjects_selected,
-                                if num_subobjects_selected == 1 { "" } else { "s" }
-                            ));
+                        if num_submodels_selected > 0 {
+                            ui.label(format!("{} Submodel{} selected.", num_submodels_selected, if num_submodels_selected == 1 { "" } else { "s" }));
 
                             let mut warnings = vec![];
 
                             if ImportType::MatchAndReplace == self.import_window.import_type {
-                                for tree_val in selection.iter().filter(|select| matches!(select, TreeValue::SubObjects(_))) {
-                                    if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = tree_val {
+                                for tree_val in selection.iter().filter(|select| matches!(select, TreeValue::Submodels(_))) {
+                                    if let TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) = tree_val {
                                         if !model
-                                            .sub_objects
+                                            .submodels
                                             .iter()
-                                            .any(|subobj| subobj.name == import_model.as_ref().unwrap().sub_objects[*id].name)
+                                            .any(|smodel| smodel.name == import_model.as_ref().unwrap().submodels[*id].name)
                                         {
                                             warnings.push(
                                                 RichText::new(format!(
-                                                    "There is no match for subobject '{}' in the recieving model. It will be added instead.",
-                                                    import_model.as_ref().unwrap().sub_objects[*id].name
+                                                    "There is no match for submodel '{}' in the recieving model. It will be added instead.",
+                                                    import_model.as_ref().unwrap().submodels[*id].name
                                                 ))
                                                 .color(WARNING_YELLOW),
                                             );
@@ -207,7 +203,7 @@ impl UiState {
                             }
 
                             if !warnings.is_empty() {
-                                ui.indent("subobject warnings", |ui| {
+                                ui.indent("submodel warnings", |ui| {
                                     for warning in warnings {
                                         ui.label(warning);
                                     }
@@ -241,18 +237,18 @@ impl UiState {
                                     let dock = &import_model.as_ref().unwrap().docking_bays[*idx];
 
                                     if let Some(id) = dock
-                                        .get_parent_obj()
-                                        .and_then(|submodel_str| import_model.as_ref().unwrap().get_obj_id_by_name(submodel_str))
+                                        .get_parent_smodel()
+                                        .and_then(|submodel_str| import_model.as_ref().unwrap().get_model_id_by_name(submodel_str))
                                     {
                                         if !self
                                             .import_window
                                             .import_selection
-                                            .contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)))
+                                            .contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(id)))
                                         {
                                             warnings.push(
                                                 RichText::new(format!(
-                                                    "Docking bay '{}' has a parent object which is not being imported. \
-                                                         The parent object field will be removed.",
+                                                    "Docking bay '{}' has a parent submodel which is not being imported. \
+                                                         The parent submodel field will be removed.",
                                                     import_model.as_ref().unwrap().docking_bays[*idx]
                                                         .get_name()
                                                         .unwrap_or(&format!("Docking bay {}", idx)),
@@ -310,11 +306,11 @@ impl UiState {
                                 if let TreeValue::Thrusters(ThrusterTreeValue::Bank(idx)) = tree_val {
                                     let import_model = &import_model.as_ref().unwrap();
                                     if let Some(subsys_name) = import_model.thruster_banks[*idx].get_engine_subsys() {
-                                        let mut found_a_match = import_model.get_obj_id_by_name(subsys_name).is_some_and(|id| {
+                                        let mut found_a_match = import_model.get_model_id_by_name(subsys_name).is_some_and(|id| {
                                             !self
                                                 .import_window
                                                 .import_selection
-                                                .contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)))
+                                                .contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(id)))
                                         });
 
                                         found_a_match |= import_model
@@ -376,14 +372,14 @@ impl UiState {
                                     if !self
                                         .import_window
                                         .import_selection
-                                        .contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(glow_bank.obj_parent)))
+                                        .contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(glow_bank.model_parent)))
                                     {
                                         let was_already_on_detail0 =
-                                            import_model.as_ref().unwrap().header.detail_levels.first() == Some(&glow_bank.obj_parent);
+                                            import_model.as_ref().unwrap().header.detail_levels.first() == Some(&glow_bank.model_parent);
                                         if !was_already_on_detail0 {
                                             warnings.push(
                                                 RichText::new(format!(
-                                                    "Glow bank {}'s object parent is not being imported; \
+                                                    "Glow bank {}'s submodel parent is not being imported; \
                                                          it will be reset to the recieving model's detail0.",
                                                     idx + 1
                                                 ))
@@ -451,17 +447,17 @@ impl UiState {
 
                                     match self.import_window.import_type {
                                         ImportType::Add => {
-                                            if !selection.contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(turret.base_obj)))
-                                                || !selection.contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(turret.gun_obj)))
+                                            if !selection.contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(turret.base_model)))
+                                                || !selection.contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(turret.gun_model)))
                                             {
-                                                // parent objects were not imported, see if we can find parents...
+                                                // parent submodels were not imported, see if we can find parents...
                                                 let mut found_match = false;
-                                                for sobj in &model.sub_objects {
-                                                    let singlepart_valid = sobj.name == import_model.sub_objects[turret.gun_obj].name
-                                                        && turret.gun_obj == turret.base_obj;
-                                                    let multipart_valid = sobj.name == import_model.sub_objects[turret.gun_obj].name
-                                                        && sobj.parent().map(|id| &model.sub_objects[id].name)
-                                                            == Some(&import_model.sub_objects[turret.base_obj].name);
+                                                for smodel in &model.submodels {
+                                                    let singlepart_valid = smodel.name == import_model.submodels[turret.gun_model].name
+                                                        && turret.gun_model == turret.base_model;
+                                                    let multipart_valid = smodel.name == import_model.submodels[turret.gun_model].name
+                                                        && smodel.parent().map(|id| &model.submodels[id].name)
+                                                            == Some(&import_model.submodels[turret.base_model].name);
 
                                                     found_match = singlepart_valid || multipart_valid;
                                                     if found_match {
@@ -473,7 +469,7 @@ impl UiState {
                                                     warnings.push(
                                                         RichText::new(format!(
                                                             "There is no match for turret '{}' in the recieving model. It will not be added.",
-                                                            import_model.sub_objects[turret.base_obj].name
+                                                            import_model.submodels[turret.base_model].name
                                                         ))
                                                         .color(ERROR_RED),
                                                     );
@@ -482,13 +478,13 @@ impl UiState {
                                         }
                                         ImportType::MatchAndReplace => {
                                             if !model.turrets.iter().any(|other_turret| {
-                                                model.sub_objects[other_turret.base_obj].name == import_model.sub_objects[turret.base_obj].name
+                                                model.submodels[other_turret.base_model].name == import_model.submodels[turret.base_model].name
                                             }) {
-                                                if !selection.contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(turret.base_obj))) {
+                                                if !selection.contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(turret.base_model))) {
                                                     warnings.push(
                                                         RichText::new(format!(
                                                             "There is no match for turret '{}' in the recieving model. It will not be added.",
-                                                            import_model.sub_objects[turret.base_obj].name
+                                                            import_model.submodels[turret.base_model].name
                                                         ))
                                                         .color(ERROR_RED),
                                                     );
@@ -496,7 +492,7 @@ impl UiState {
                                                     warnings.push(
                                                         RichText::new(format!(
                                                             "There is no match for turret '{}' in the recieving model. It will be added instead.",
-                                                            import_model.sub_objects[turret.base_obj].name
+                                                            import_model.submodels[turret.base_model].name
                                                         ))
                                                         .color(WARNING_YELLOW),
                                                     );
@@ -558,10 +554,10 @@ impl UiState {
                                     let point = &import_model.as_ref().unwrap().eye_points[*idx];
 
                                     if self.import_window.import_type == ImportType::MatchAndReplace {
-                                        let attached_obj = point.attached_subobj.map(|id| &import_model.as_ref().unwrap().sub_objects[id].name);
+                                        let attached_smodel = point.attached_submodel.map(|id| &import_model.as_ref().unwrap().submodels[id].name);
 
                                         if !model.eye_points.iter().any(|other_point| {
-                                            other_point.attached_subobj.map(|id| &model.pof_model.sub_objects[id].name) == attached_obj
+                                            other_point.attached_submodel.map(|id| &model.pof_model.submodels[id].name) == attached_smodel
                                         }) {
                                             warnings.push(
                                                 RichText::new(format!(
@@ -659,30 +655,30 @@ impl UiState {
                         toggle(&mut self.import_window.import_selection, TreeValue::Header);
                     }
 
-                    // SubObjects
-                    fn make_subobject_child_list(
-                        import_model: &pof::Model, selection: &mut BTreeSet<TreeValue>, object: &SubObject, ui: &mut Ui, bother_with_coloring: bool,
+                    // Submodels
+                    fn make_submodel_child_list(
+                        import_model: &pof::Model, selection: &mut BTreeSet<TreeValue>, smodel: &Submodel, ui: &mut Ui, bother_with_coloring: bool,
                         options: &ImportOptions,
                     ) {
-                        let tree_val = TreeValue::SubObjects(SubObjectTreeValue::SubObject(object.obj_id));
+                        let tree_val = TreeValue::Submodels(SubmodelTreeValue::Submodel(smodel.id));
                         let selection_status = {
                             if bother_with_coloring {
                                 if selection.contains(&tree_val) {
                                     SelectionType::Total
                                 } else {
-                                    let mut num_subobjects = 0;
-                                    let mut selected_subobjects = 0;
-                                    import_model.do_for_recursive_subobj_children(object.obj_id, &mut |obj| {
-                                        num_subobjects += 1;
-                                        if selection.contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(obj.obj_id))) {
-                                            selected_subobjects += 1;
+                                    let mut num_submodels = 0;
+                                    let mut selected_submodels = 0;
+                                    import_model.do_for_recursive_smodel_children(smodel.id, &mut |smodel| {
+                                        num_submodels += 1;
+                                        if selection.contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(smodel.id))) {
+                                            selected_submodels += 1;
                                         }
                                     });
 
-                                    match (num_subobjects, selected_subobjects) {
+                                    match (num_submodels, selected_submodels) {
                                         (_, 0) => SelectionType::None,
-                                        (_, _) if selected_subobjects < num_subobjects => SelectionType::Partial,
-                                        (_, _) if selected_subobjects == num_subobjects => SelectionType::Total,
+                                        (_, _) if selected_submodels < num_submodels => SelectionType::Partial,
+                                        (_, _) if selected_submodels == num_submodels => SelectionType::Total,
                                         _ => unreachable!(),
                                     }
                                 }
@@ -691,20 +687,20 @@ impl UiState {
                             }
                         };
 
-                        if object.children().next().is_none() {
-                            if selectable_label(ui, selection_status, &object.name).clicked() {
+                        if smodel.children().next().is_none() {
+                            if selectable_label(ui, selection_status, &smodel.name).clicked() {
                                 toggle(selection, tree_val);
 
                                 if options.auto_select_turrets {
                                     for (i, turret) in import_model.turrets.iter().enumerate() {
-                                        if turret.base_obj == object.obj_id {
+                                        if turret.base_model == smodel.id {
                                             set(selection, selection.contains(&tree_val), TreeValue::Turrets(TurretTreeValue::Turret(i)));
                                         }
                                     }
                                 }
                                 if options.auto_select_paths {
                                     for (i, path) in import_model.paths.iter().enumerate() {
-                                        if path.parent.to_lowercase() == object.name.to_lowercase() {
+                                        if path.parent.to_lowercase() == smodel.name.to_lowercase() {
                                             set(selection, selection.contains(&tree_val), TreeValue::Paths(PathTreeValue::Path(i)));
                                         }
                                     }
@@ -715,27 +711,27 @@ impl UiState {
                             let header_is_open = state.is_open();
                             state
                                 .show_header(ui, |ui| {
-                                    if selectable_label(ui, selection_status, &object.name).clicked() {
+                                    if selectable_label(ui, selection_status, &smodel.name).clicked() {
                                         toggle(selection, tree_val);
 
-                                        if options.auto_select_subobj_children {
-                                            // a bit confusing, but do_for_recursive_subobj_children will also run on the subobject you call it on
+                                        if options.auto_select_smodel_children {
+                                            // a bit confusing, but do_for_recursive_smodel_children will also run on the submodel you call it on
                                             // so save its selection status now, rather than accidentally toggle it back to its old status
                                             let enable_disable = selection.contains(&tree_val);
-                                            import_model.do_for_recursive_subobj_children(object.obj_id, &mut |obj| {
-                                                set(selection, enable_disable, TreeValue::SubObjects(SubObjectTreeValue::SubObject(obj.obj_id)));
+                                            import_model.do_for_recursive_smodel_children(smodel.id, &mut |smodel| {
+                                                set(selection, enable_disable, TreeValue::Submodels(SubmodelTreeValue::Submodel(smodel.id)));
                                             });
                                         }
                                         if options.auto_select_turrets {
                                             for (i, turret) in import_model.turrets.iter().enumerate() {
-                                                if turret.base_obj == object.obj_id {
+                                                if turret.base_model == smodel.id {
                                                     set(selection, selection.contains(&tree_val), TreeValue::Turrets(TurretTreeValue::Turret(i)));
                                                 }
                                             }
                                         }
                                         if options.auto_select_paths {
                                             for (i, path) in import_model.paths.iter().enumerate() {
-                                                if path.parent.to_lowercase() == object.name.to_lowercase() {
+                                                if path.parent.to_lowercase() == smodel.name.to_lowercase() {
                                                     set(selection, selection.contains(&tree_val), TreeValue::Paths(PathTreeValue::Path(i)));
                                                 }
                                             }
@@ -743,43 +739,43 @@ impl UiState {
                                     }
                                 })
                                 .body(|ui| {
-                                    for &i in object.children() {
-                                        make_subobject_child_list(import_model, selection, &import_model.sub_objects[i], ui, header_is_open, options)
+                                    for &i in smodel.children() {
+                                        make_submodel_child_list(import_model, selection, &import_model.submodels[i], ui, header_is_open, options)
                                     }
                                 });
                         }
                     }
 
-                    if !import_model.sub_objects.is_empty() {
-                        let state = CollapsingState::load_with_default_open(ui.ctx(), Id::new("import SubObjects"), false);
+                    if !import_model.submodels.is_empty() {
+                        let state = CollapsingState::load_with_default_open(ui.ctx(), Id::new("import Submodels"), false);
                         let header_is_open = state.is_open();
                         let selection_status =
-                            get_selection_status!(import_model.sub_objects, |i| TreeValue::SubObjects(SubObjectTreeValue::SubObject(i.1.obj_id)));
+                            get_selection_status!(import_model.submodels, |i| TreeValue::Submodels(SubmodelTreeValue::Submodel(i.1.id)));
                         state
                             .show_header(ui, |ui| {
-                                if selectable_label(ui, selection_status, format!("SubObjects ({})", import_model.sub_objects.len())).clicked() {
-                                    if num_subobjects_selected == import_model.sub_objects.len() {
-                                        for object in &import_model.sub_objects {
+                                if selectable_label(ui, selection_status, format!("Submodels ({})", import_model.submodels.len())).clicked() {
+                                    if num_submodels_selected == import_model.submodels.len() {
+                                        for smodel in &import_model.submodels {
                                             self.import_window
                                                 .import_selection
-                                                .remove(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(object.obj_id)));
+                                                .remove(&TreeValue::Submodels(SubmodelTreeValue::Submodel(smodel.id)));
                                         }
                                     } else {
-                                        for object in &import_model.sub_objects {
+                                        for smodel in &import_model.submodels {
                                             self.import_window
                                                 .import_selection
-                                                .insert(TreeValue::SubObjects(SubObjectTreeValue::SubObject(object.obj_id)));
+                                                .insert(TreeValue::Submodels(SubmodelTreeValue::Submodel(smodel.id)));
                                         }
                                     }
                                 }
                             })
                             .body(|ui| {
-                                for object in &import_model.sub_objects {
-                                    if object.parent().is_none() {
-                                        make_subobject_child_list(
+                                for smodel in &import_model.submodels {
+                                    if smodel.parent().is_none() {
+                                        make_submodel_child_list(
                                             import_model,
                                             &mut self.import_window.import_selection,
-                                            object,
+                                            smodel,
                                             ui,
                                             header_is_open,
                                             &self.import_window.import_options,
@@ -984,7 +980,7 @@ impl UiState {
                                     |i| TreeValue::Turrets(TurretTreeValue::Turret(i.0))
                                 ),
                             )
-                            .body(body_stuff!(turrets, |turret| format!("{}", import_model.sub_objects[turret.base_obj].name), |i| {
+                            .body(body_stuff!(turrets, |turret| format!("{}", import_model.submodels[turret.base_model].name), |i| {
                                 TreeValue::Turrets(TurretTreeValue::Turret(i))
                             }));
                     }
@@ -1103,21 +1099,21 @@ impl PofToolsGui {
         let selection = std::mem::take(&mut self.import_window.import_selection);
         let mut import_model = std::mem::take(&mut self.import_window.model).unwrap();
 
-        // make the object id map to translate old object ids to new object ids
-        let mut obj_id_map = HashMap::new();
-        let mut num_subobjects = self.model.sub_objects.len();
+        // make the model id map to translate old model ids to new model ids
+        let mut model_id_map = HashMap::new();
+        let mut num_submodels = self.model.submodels.len();
         for tree_val in &selection {
-            if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = *tree_val {
+            if let TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) = *tree_val {
                 let new_id = match self.import_window.import_type {
                     ImportType::Add => {
-                        num_subobjects += 1;
-                        ObjectId((num_subobjects - 1) as u32)
+                        num_submodels += 1;
+                        SubmodelId((num_submodels - 1) as u32)
                     }
                     ImportType::MatchAndReplace => {
                         let mut replaced_id = None;
-                        for subobj in &self.model.sub_objects {
-                            if subobj.name == import_model.sub_objects[id].name {
-                                replaced_id = Some(subobj.obj_id);
+                        for smodel in &self.model.submodels {
+                            if smodel.name == import_model.submodels[id].name {
+                                replaced_id = Some(smodel.id);
                                 break;
                             }
                         }
@@ -1126,17 +1122,17 @@ impl PofToolsGui {
                             replaced_id
                         } else {
                             //uh oh, just add instead?
-                            num_subobjects += 1;
-                            ObjectId((num_subobjects - 1) as u32)
+                            num_submodels += 1;
+                            SubmodelId((num_submodels - 1) as u32)
                         }
                     }
                 };
-                obj_id_map.insert(id, new_id);
+                model_id_map.insert(id, new_id);
             }
         }
 
         // we're mangling the import_model as we go, so order is VERY IMPORTANT
-        // do the things which require the subobjects still be intact
+        // do the things which require the submode; still be intact
         for tree_val in &selection {
             match *tree_val {
                 TreeValue::Header => {
@@ -1148,12 +1144,12 @@ impl PofToolsGui {
                     self.model.header.moment_of_inertia = header.moment_of_inertia;
                 }
                 TreeValue::DockingBays(DockingTreeValue::Bay(idx)) => {
-                    // requires getting subobjects by name -> still have to be intact
+                    // requires getting submodels by name -> still have to be intact
                     let mut dock = std::mem::take(&mut import_model.docking_bays[idx]);
-                    if let Some(parent_name) = dock.get_parent_obj() {
+                    if let Some(parent_name) = dock.get_parent_smodel() {
                         if import_model
-                            .get_obj_id_by_name(parent_name)
-                            .is_some_and(|id| !obj_id_map.contains_key(&id))
+                            .get_model_id_by_name(parent_name)
+                            .is_some_and(|id| !model_id_map.contains_key(&id))
                         {
                             // parent submodel was not imported, lose it
                             properties_delete_field(&mut dock.properties, "$parent_submodel");
@@ -1184,12 +1180,12 @@ impl PofToolsGui {
                 }
                 TreeValue::DockingBays(_) => unreachable!(),
                 TreeValue::Thrusters(ThrusterTreeValue::Bank(idx)) => {
-                    // requires getting subobjects by name -> still have to be intact
+                    // requires getting submodels by name -> still have to be intact
                     let mut t_bank = std::mem::take(&mut import_model.thruster_banks[idx]);
                     if let Some(subsys_name) = t_bank.get_engine_subsys() {
                         let mut found_a_match = import_model
-                            .get_obj_id_by_name(subsys_name)
-                            .is_some_and(|id| !obj_id_map.contains_key(&id));
+                            .get_model_id_by_name(subsys_name)
+                            .is_some_and(|id| !model_id_map.contains_key(&id));
 
                         found_a_match |= import_model
                             .special_points
@@ -1229,18 +1225,18 @@ impl PofToolsGui {
                 TreeValue::Glows(GlowTreeValue::Bank(idx)) => {
                     let mut g_bank = std::mem::take(&mut import_model.glow_banks[idx]);
 
-                    if !obj_id_map.contains_key(&g_bank.obj_parent) {
+                    if !model_id_map.contains_key(&g_bank.model_parent) {
                         // reset it to detail0
-                        // ... if theres no detail0, just the first subobject
-                        // ... if theres no objects, skip it i guess
+                        // ... if theres no detail0, just the first submodel
+                        // ... if theres no models, skip it i guess
                         if let Some(id) = self
                             .model
                             .header
                             .detail_levels
                             .first()
-                            .or_else(|| self.model.sub_objects.first().map(|sobj| &sobj.obj_id))
+                            .or_else(|| self.model.submodels.first().map(|smodel| &smodel.id))
                         {
-                            g_bank.obj_parent = *id;
+                            g_bank.model_parent = *id;
                         } else {
                             continue;
                         }
@@ -1254,30 +1250,30 @@ impl PofToolsGui {
 
                     match self.import_window.import_type {
                         ImportType::Add => {
-                            if selection.contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(turret.base_obj)))
-                                && selection.contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(turret.gun_obj)))
+                            if selection.contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(turret.base_model)))
+                                && selection.contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(turret.gun_model)))
                             {
-                                // parent objects were imported too, cool
-                                turret.base_obj = obj_id_map[&turret.base_obj];
-                                turret.gun_obj = obj_id_map[&turret.gun_obj];
+                                // parent models were imported too, cool
+                                turret.base_model = model_id_map[&turret.base_model];
+                                turret.gun_model = model_id_map[&turret.gun_model];
                             } else {
-                                // parent objects were not imported, see if we can find parents...
+                                // parent models were not imported, see if we can find parents...
                                 let mut found_match = false;
-                                for sobj in &self.model.sub_objects {
+                                for smodel in &self.model.submodels {
                                     let singlepart_valid =
-                                        sobj.name == import_model.sub_objects[turret.gun_obj].name && turret.gun_obj == turret.base_obj;
-                                    let multipart_valid = sobj.name == import_model.sub_objects[turret.gun_obj].name
-                                        && sobj.parent().map(|id| &self.model.sub_objects[id].name)
-                                            == Some(&import_model.sub_objects[turret.base_obj].name);
+                                        smodel.name == import_model.submodels[turret.gun_model].name && turret.gun_model == turret.base_model;
+                                    let multipart_valid = smodel.name == import_model.submodels[turret.gun_model].name
+                                        && smodel.parent().map(|id| &self.model.submodels[id].name)
+                                            == Some(&import_model.submodels[turret.base_model].name);
 
                                     if singlepart_valid {
                                         found_match = true;
-                                        turret.gun_obj = sobj.obj_id;
-                                        turret.base_obj = sobj.obj_id;
+                                        turret.gun_model = smodel.id;
+                                        turret.base_model = smodel.id;
                                     } else if multipart_valid {
                                         found_match = true;
-                                        turret.gun_obj = sobj.obj_id;
-                                        turret.base_obj = sobj.parent().unwrap();
+                                        turret.gun_model = smodel.id;
+                                        turret.base_model = smodel.parent().unwrap();
                                     }
                                 }
 
@@ -1290,22 +1286,22 @@ impl PofToolsGui {
                         ImportType::MatchAndReplace => {
                             // find and replace
                             if let Some(replaced_turret) = self.model.pof_model.turrets.iter_mut().find(|replaced_turret| {
-                                self.model.pof_model.sub_objects[replaced_turret.base_obj].name == import_model.sub_objects[turret.base_obj].name
+                                self.model.pof_model.submodels[replaced_turret.base_model].name == import_model.submodels[turret.base_model].name
                             }) {
-                                turret.base_obj = replaced_turret.base_obj;
-                                turret.gun_obj = if obj_id_map.contains_key(&turret.gun_obj) {
-                                    obj_id_map[&turret.gun_obj] // prefer an imported gun obj, instead of the replace turret's
+                                turret.base_model = replaced_turret.base_model;
+                                turret.gun_model = if model_id_map.contains_key(&turret.gun_model) {
+                                    model_id_map[&turret.gun_model] // prefer an imported gun model, instead of the replace turret's
                                 } else {
-                                    replaced_turret.gun_obj
+                                    replaced_turret.gun_model
                                 };
                                 *replaced_turret = turret;
-                            } else if selection.contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(turret.base_obj)))
-                                && selection.contains(&TreeValue::SubObjects(SubObjectTreeValue::SubObject(turret.gun_obj)))
+                            } else if selection.contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(turret.base_model)))
+                                && selection.contains(&TreeValue::Submodels(SubmodelTreeValue::Submodel(turret.gun_model)))
                             {
                                 // fall back, try to add it
-                                // parent objects were imported too, cool
-                                turret.base_obj = obj_id_map[&turret.base_obj];
-                                turret.gun_obj = obj_id_map[&turret.gun_obj];
+                                // parent models were imported too, cool
+                                turret.base_model = model_id_map[&turret.base_model];
+                                turret.gun_model = model_id_map[&turret.gun_model];
                                 self.model.turrets.push(turret);
                             }
                             // else just lose it
@@ -1321,12 +1317,12 @@ impl PofToolsGui {
                             self.model.eye_points.push(point);
                         }
                         ImportType::MatchAndReplace => {
-                            let attached_obj = point.attached_subobj.map(|id| &import_model.sub_objects[id].name);
+                            let attached_model = point.attached_submodel.map(|id| &import_model.submodels[id].name);
                             // find and replace
                             if let Some(replaced_point) = self.model.pof_model.eye_points.iter_mut().find(|replaced_point| {
-                                replaced_point.attached_subobj.map(|id| &self.model.pof_model.sub_objects[id].name) == attached_obj
+                                replaced_point.attached_submodel.map(|id| &self.model.pof_model.submodels[id].name) == attached_model
                             }) {
-                                point.attached_subobj = replaced_point.attached_subobj;
+                                point.attached_submodel = replaced_point.attached_submodel;
                                 *replaced_point = point;
                             } else {
                                 // fall back, just add it
@@ -1352,20 +1348,20 @@ impl PofToolsGui {
                 TreeValue::Insignia(_) => unreachable!(),
                 TreeValue::VisualCenter => unreachable!(), // should this be importable?
                 TreeValue::Comments => unreachable!(),     // should this be importable?
-                TreeValue::SubObjects(_) => (),
+                TreeValue::Submodels(_) => (),
                 TreeValue::Weapons(_) => (),
                 TreeValue::Textures(_) => unreachable!(),
                 _ => (),
             }
         }
 
-        let old_subobj_len = self.model.sub_objects.len();
+        let old_smodel_len = self.model.submodels.len();
         for tree_val in &selection {
             match *tree_val {
-                TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) => {
+                TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) => {
                     // translate old texure ids to new one
                     let mut tex_id_map = HashMap::new();
-                    for (_, poly) in import_model.sub_objects[id].bsp_data.collision_tree.leaves_mut() {
+                    for (_, poly) in import_model.submodels[id].bsp_data.collision_tree.leaves_mut() {
                         if let Entry::Vacant(e) = tex_id_map.entry(poly.texture) {
                             // see if this texture already exists
                             if let Some(i) =
@@ -1382,26 +1378,26 @@ impl PofToolsGui {
                         poly.texture = tex_id_map[&poly.texture];
                     }
 
-                    let import_subobj = &mut import_model.sub_objects[id];
-                    import_subobj.obj_id = obj_id_map[&id];
+                    let import_submodel = &mut import_model.submodels[id];
+                    import_submodel.id = model_id_map[&id];
 
                     // make da swap (or addition)
-                    if import_subobj.obj_id.0 as usize >= old_subobj_len {
-                        if let Some(parent_id) = import_subobj.parent {
-                            import_subobj.parent = obj_id_map.get(&parent_id).copied();
+                    if import_submodel.id.0 as usize >= old_smodel_len {
+                        if let Some(parent_id) = import_submodel.parent {
+                            import_submodel.parent = model_id_map.get(&parent_id).copied();
                         }
 
-                        self.model.sub_objects.push(std::mem::take(import_subobj));
-                        self.model.header.num_subobjects += 1;
+                        self.model.submodels.push(std::mem::take(import_submodel));
+                        self.model.header.num_submodels += 1;
                     } else {
-                        let target_subobj = &mut self.model.sub_objects[import_subobj.obj_id];
-                        // if you're replacing a subobj, you inherit the parent of what you've replaced
-                        import_subobj.parent = target_subobj.parent;
+                        let target_submodel = &mut self.model.submodels[import_submodel.id];
+                        // if you're replacing a submodel, you inherit the parent of what you've replaced
+                        import_submodel.parent = target_submodel.parent;
 
                         // also inherit position
-                        import_subobj.offset = target_subobj.offset;
+                        import_submodel.offset = target_submodel.offset;
 
-                        *target_subobj = std::mem::take(import_subobj);
+                        *target_submodel = std::mem::take(import_submodel);
                     }
                 }
                 TreeValue::Weapons(WeaponTreeValue::PriBank(idx)) => {

--- a/src/ui_properties_panel.rs
+++ b/src/ui_properties_panel.rs
@@ -11,7 +11,7 @@ use glium::glutin::surface::WindowSurface;
 use glium::Display;
 use nalgebra_glm::TMat4;
 use pof::{
-    Dock, Error, NormalVec3, ObjectId, PathId, Set::*, SubsysRotationAxis, SubsysRotationType, SubsysTranslationAxis, SubsysTranslationType, Vec3d,
+    Dock, Error, NormalVec3, PathId, Set::*, SubmodelId, SubsysRotationAxis, SubsysRotationType, SubsysTranslationAxis, SubsysTranslationType, Vec3d,
     Warning,
 };
 
@@ -19,7 +19,7 @@ use crate::Model;
 
 use crate::ui::{
     model_action, DockingTreeValue, EyeTreeValue, GlowTreeValue, InsigniaTreeValue, PathTreeValue, PofToolsGui, SpecialPointTreeValue,
-    SubObjectTreeValue, TextureTreeValue, ThrusterTreeValue, TreeValue, TurretTreeValue, UiState, UndoAction, WeaponTreeValue, ERROR_RED, LIGHT_BLUE,
+    SubmodelTreeValue, TextureTreeValue, ThrusterTreeValue, TreeValue, TurretTreeValue, UiState, UndoAction, WeaponTreeValue, ERROR_RED, LIGHT_BLUE,
     LIGHT_ORANGE, WARNING_YELLOW,
 };
 
@@ -329,9 +329,9 @@ impl UiState {
         ret
     }
 
-    // a combo box for subobjects
+    // a combo box for submodels
     // selector value is a convenience option to disable the combo box, since most properties panels work on a current selection of Option<something>
-    fn subobject_combo_box<T>(
+    fn submodel_combo_box<T>(
         ui: &mut Ui, name_list: &[String], mut_selection: &mut usize, selector_value: Option<T>, label: &str, active_error_idx: Option<usize>,
         active_warning_idx: Option<usize>,
     ) -> Option<usize> {
@@ -598,18 +598,18 @@ impl UiState {
                     transform_window: Default::default(),
                 }
             }
-            TreeValue::SubObjects(subobj_tree_select) => match subobj_tree_select {
-                SubObjectTreeValue::Header => self.properties_panel = PropertiesPanel::default_subobject(),
-                SubObjectTreeValue::SubObject(id) => {
-                    self.properties_panel = PropertiesPanel::SubObject {
-                        bbox_max_string: format!("{}", model.sub_objects[id].bbox.max),
-                        bbox_min_string: format!("{}", model.sub_objects[id].bbox.min),
-                        offset_string: format!("{}", model.sub_objects[id].offset),
-                        radius_string: format!("{}", model.sub_objects[id].radius),
-                        is_debris_check: model.sub_objects[id].is_debris_model,
-                        name: format!("{}", model.sub_objects[id].name),
-                        rot_axis: model.sub_objects[id].rotation_axis,
-                        trans_axis: model.sub_objects[id].translation_axis,
+            TreeValue::Submodels(submodel_tree_select) => match submodel_tree_select {
+                SubmodelTreeValue::Header => self.properties_panel = PropertiesPanel::default_submodel(),
+                SubmodelTreeValue::Submodel(id) => {
+                    self.properties_panel = PropertiesPanel::Submodel {
+                        bbox_max_string: format!("{}", model.submodels[id].bbox.max),
+                        bbox_min_string: format!("{}", model.submodels[id].bbox.min),
+                        offset_string: format!("{}", model.submodels[id].offset),
+                        radius_string: format!("{}", model.submodels[id].radius),
+                        is_debris_check: model.submodels[id].is_debris_model,
+                        name: format!("{}", model.submodels[id].name),
+                        rot_axis: model.submodels[id].rotation_axis,
+                        trans_axis: model.submodels[id].translation_axis,
                         transform_window: Default::default(),
                     }
                 }
@@ -683,7 +683,7 @@ impl UiState {
                         disp_time_string: format!("{}", model.glow_banks[bank].disp_time),
                         on_time_string: format!("{}", model.glow_banks[bank].on_time),
                         off_time_string: format!("{}", model.glow_banks[bank].off_time),
-                        attached_subobj_idx: model.glow_banks[bank].obj_parent.0 as usize,
+                        attached_submodel_idx: model.glow_banks[bank].model_parent.0 as usize,
                         lod_string: format!("{}", model.glow_banks[bank].lod),
                         glow_type_string: format!("{}", model.glow_banks[bank].glow_type),
                         glow_texture_string: format!(
@@ -700,7 +700,7 @@ impl UiState {
                         disp_time_string: format!("{}", model.glow_banks[bank].disp_time),
                         on_time_string: format!("{}", model.glow_banks[bank].on_time),
                         off_time_string: format!("{}", model.glow_banks[bank].off_time),
-                        attached_subobj_idx: model.glow_banks[bank].obj_parent.0 as usize,
+                        attached_submodel_idx: model.glow_banks[bank].model_parent.0 as usize,
                         lod_string: format!("{}", model.glow_banks[bank].lod),
                         glow_type_string: format!("{}", model.glow_banks[bank].glow_type),
                         glow_texture_string: format!(
@@ -728,14 +728,14 @@ impl UiState {
                 TurretTreeValue::TurretPoint(turret, point) => {
                     self.properties_panel = PropertiesPanel::Turret {
                         normal_string: format!("{}", model.turrets[turret].normal.0),
-                        base_idx: model.turrets[turret].base_obj.0 as usize,
+                        base_idx: model.turrets[turret].base_model.0 as usize,
                         position_string: format!("{}", model.turrets[turret].fire_points[point]),
                     }
                 }
                 TurretTreeValue::Turret(turret) => {
                     self.properties_panel = PropertiesPanel::Turret {
                         normal_string: format!("{}", model.turrets[turret].normal.0),
-                        base_idx: model.turrets[turret].base_obj.0 as usize,
+                        base_idx: model.turrets[turret].base_model.0 as usize,
                         position_string: Default::default(),
                     }
                 }
@@ -774,7 +774,7 @@ impl UiState {
                     self.properties_panel = PropertiesPanel::EyePoint {
                         position_string: format!("{}", model.eye_points[idx].position),
                         normal_string: format!("{}", model.eye_points[idx].normal.0),
-                        attached_subobj_idx: model.eye_points[idx].attached_subobj.map_or(model.sub_objects.len(), |id| id.0 as usize),
+                        attached_submodel_idx: model.eye_points[idx].attached_submodel.map_or(model.submodels.len(), |id| id.0 as usize),
                     }
                 }
                 _ => self.properties_panel = PropertiesPanel::default_eye(),
@@ -818,7 +818,7 @@ pub enum PropertiesPanel {
         moif_string: String,
         transform_window: TransformWindow,
     },
-    SubObject {
+    Submodel {
         bbox_min_string: String,
         bbox_max_string: String,
         name: String,
@@ -854,7 +854,7 @@ pub enum PropertiesPanel {
         disp_time_string: String,
         on_time_string: String,
         off_time_string: String,
-        attached_subobj_idx: usize,
+        attached_submodel_idx: usize,
         lod_string: String,
         glow_type_string: String,
         glow_texture_string: String,
@@ -886,7 +886,7 @@ pub enum PropertiesPanel {
     EyePoint {
         position_string: String,
         normal_string: String,
-        attached_subobj_idx: usize,
+        attached_submodel_idx: usize,
     },
     VisualCenter {
         position: String,
@@ -914,8 +914,8 @@ impl Default for PropertiesPanel {
     }
 }
 impl PropertiesPanel {
-    fn default_subobject() -> Self {
-        Self::SubObject {
+    fn default_submodel() -> Self {
+        Self::Submodel {
             bbox_min_string: Default::default(),
             bbox_max_string: Default::default(),
             name: Default::default(),
@@ -966,7 +966,7 @@ impl PropertiesPanel {
             disp_time_string: Default::default(),
             on_time_string: Default::default(),
             off_time_string: Default::default(),
-            attached_subobj_idx: Default::default(),
+            attached_submodel_idx: Default::default(),
             lod_string: Default::default(),
             glow_texture_string: Default::default(),
             glow_type_string: Default::default(),
@@ -1000,7 +1000,7 @@ impl PropertiesPanel {
         Self::EyePoint {
             position_string: Default::default(),
             normal_string: Default::default(),
-            attached_subobj_idx: 0,
+            attached_submodel_idx: 0,
         }
     }
     fn default_insignia() -> Self {
@@ -1214,27 +1214,27 @@ impl PofToolsGui {
 
                 for (i, &id) in self.model.header.detail_levels.iter().enumerate() {
                     let mut combo_idx = 0;
-                    let mut listed_objects = vec![];
+                    let mut listed_models = vec![];
                     let mut active_warning_idx = None;
 
-                    // add all the valid objects
-                    for subobj in &self.model.sub_objects {
-                        if subobj.parent().is_some() || subobj.is_debris_model {
+                    // add all the valid models
+                    for smodel in &self.model.submodels {
+                        if smodel.parent().is_some() || smodel.is_debris_model {
                             continue;
                         }
 
-                        if subobj.obj_id == id {
-                            combo_idx = listed_objects.len();
+                        if smodel.id == id {
+                            combo_idx = listed_models.len();
                         }
 
-                        listed_objects.push(subobj.name.clone());
+                        listed_models.push(smodel.name.clone());
                     }
 
                     // if we have an invalid one add that too
-                    if self.model.sub_objects[id].parent().is_some() {
-                        combo_idx = listed_objects.len();
+                    if self.model.submodels[id].parent().is_some() {
+                        combo_idx = listed_models.len();
                         active_warning_idx = Some(combo_idx);
-                        listed_objects.push(self.model.sub_objects[id].name.clone());
+                        listed_models.push(self.model.submodels[id].name.clone());
                     }
 
                     if self.model.warnings.contains(&Warning::DuplicateDetailLevel(id)) {
@@ -1242,44 +1242,44 @@ impl PofToolsGui {
                     }
 
                     //finally add a "None" option
-                    listed_objects.push(format!("None"));
+                    listed_models.push(format!("None"));
 
                     if let Some(new_idx) =
-                        UiState::subobject_combo_box(ui, &listed_objects, &mut combo_idx, Some(()), &format!("- {}", i), None, active_warning_idx)
+                        UiState::submodel_combo_box(ui, &listed_models, &mut combo_idx, Some(()), &format!("- {}", i), None, active_warning_idx)
                     {
-                        if new_idx == listed_objects.len() - 1 {
+                        if new_idx == listed_models.len() - 1 {
                             changed_detail = Some((i, None));
                         } else {
-                            changed_detail = Some((i, self.model.get_obj_id_by_name(&listed_objects[new_idx])));
+                            changed_detail = Some((i, self.model.get_model_id_by_name(&listed_models[new_idx])));
                         }
                     }
                 }
 
                 // add a special dummy detail level so that users can add new ones
                 {
-                    let mut listed_objects: Vec<String> = self
+                    let mut listed_models: Vec<String> = self
                         .model
-                        .sub_objects
+                        .submodels
                         .iter()
-                        .filter(|subobj| subobj.parent().is_none() && !subobj.is_debris_model)
-                        .map(|subobj| subobj.name.clone())
+                        .filter(|smodel| smodel.parent().is_none() && !smodel.is_debris_model)
+                        .map(|smodel| smodel.name.clone())
                         .collect();
-                    listed_objects.push(format!("None"));
+                    listed_models.push(format!("None"));
 
-                    let mut combo_idx = listed_objects.len() - 1;
-                    if let Some(new_idx) = UiState::subobject_combo_box(
+                    let mut combo_idx = listed_models.len() - 1;
+                    if let Some(new_idx) = UiState::submodel_combo_box(
                         ui,
-                        &listed_objects,
+                        &listed_models,
                         &mut combo_idx,
                         Some(()),
                         &format!("- {}", self.model.header.detail_levels.len()),
                         None,
                         None,
                     ) {
-                        if new_idx == listed_objects.len() - 1 {
+                        if new_idx == listed_models.len() - 1 {
                             changed_detail = Some((self.model.header.detail_levels.len(), None));
                         } else {
-                            changed_detail = Some((self.model.header.detail_levels.len(), self.model.get_obj_id_by_name(&listed_objects[new_idx])));
+                            changed_detail = Some((self.model.header.detail_levels.len(), self.model.get_model_id_by_name(&listed_models[new_idx])));
                         }
                     }
                 }
@@ -1323,7 +1323,7 @@ impl PofToolsGui {
 
                 let mut text = LayoutJob::default();
                 text.append(
-                    "This will affect all subobjects, all weapon points, docking points etc. and ",
+                    "This will affect all submodels, all weapon points, docking points etc. and ",
                     0.0,
                     TextFormat {
                         font_id: TextStyle::Body.resolve(ui.style()),
@@ -1352,14 +1352,14 @@ impl PofToolsGui {
 
                 let mut num_verts = 0;
                 let mut num_norms = 0;
-                for subobj in &self.model.sub_objects {
-                    num_verts += subobj.bsp_data.verts.len();
-                    num_norms += subobj.bsp_data.norms.len();
+                for smodel in &self.model.submodels {
+                    num_verts += smodel.bsp_data.verts.len();
+                    num_norms += smodel.bsp_data.norms.len();
                 }
                 ui.label(RichText::new(format!("Total vertices: {}", num_verts)).weak());
                 ui.label(RichText::new(format!("Total normals: {}", num_norms)).weak());
             }
-            PropertiesPanel::SubObject {
+            PropertiesPanel::Submodel {
                 bbox_min_string,
                 bbox_max_string,
                 name,
@@ -1370,14 +1370,14 @@ impl PofToolsGui {
                 trans_axis,
                 transform_window,
             } => {
-                let mut selected_id = if let TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)) = current_tree_selection {
+                let mut selected_id = if let TreeValue::Submodels(SubmodelTreeValue::Submodel(id)) = current_tree_selection {
                     Some(id)
                 } else {
                     None
                 };
 
                 ui.horizontal(|ui| {
-                    ui.heading("SubObject");
+                    ui.heading("Submodel");
                     ui.add_space(ui.available_width() - 70.0);
 
                     // Actions menu ===================================================================
@@ -1389,22 +1389,22 @@ impl PofToolsGui {
                             }
 
                             if ui.button("Duplicate").clicked() {
-                                let new_id = ObjectId(self.model.sub_objects.len() as u32);
-                                let mut new_subobj = self.model.sub_objects[id].clone();
-                                new_subobj.children.clear(); // we aren't duplicating the children
-                                new_subobj.obj_id = new_id;
+                                let new_id = SubmodelId(self.model.submodels.len() as u32);
+                                let mut new_smodel = self.model.submodels[id].clone();
+                                new_smodel.children.clear(); // we aren't duplicating the children
+                                new_smodel.id = new_id;
 
-                                new_subobj.name = format!("{} - Copy", new_subobj.name);
+                                new_smodel.name = format!("{} - Copy", new_smodel.name);
 
                                 // a lot of work for this gag
-                                let mut lowest_moron = 0;
+                                let mut lowest_moron = 1;
                                 let mut user_is_moronic = false;
-                                for subobj in &self.model.sub_objects {
-                                    if subobj.name == new_subobj.name {
+                                for smodel in &self.model.submodels {
+                                    if smodel.name == new_smodel.name && !self.model.submodel_duplicated[smodel.id] {
                                         user_is_moronic = true;
                                     }
-                                    if subobj.name.starts_with("U.R.A Moron ") {
-                                        let digits = subobj
+                                    if smodel.name.starts_with("U.R.A Moron ") {
+                                        let digits = smodel
                                             .name
                                             .trim_end()
                                             .chars()
@@ -1418,12 +1418,13 @@ impl PofToolsGui {
                                 }
 
                                 if user_is_moronic {
-                                    new_subobj.name = format!("U.R.A Moron {}", lowest_moron);
+                                    new_smodel.name = format!("U.R.A Moron {}", lowest_moron);
                                 }
 
-                                let mut new_bufs = Some(self.model.buffer_objects[id].clone(display));
-                                let mut mat = Some(self.model.subobject_transform_matrix[id]);
-                                let mut new_subobj = Some(new_subobj);
+                                let mut new_bufs = Some(self.model.buffer_meshes[id].clone(display));
+                                let mut mat = Some(self.model.submodel_transform_matrix[id]);
+                                let mut duped = Some(true);
+                                let mut new_smodel = Some(new_smodel);
 
                                 let mut undo = false;
 
@@ -1432,21 +1433,23 @@ impl PofToolsGui {
                                     &mut self.model,
                                     undo_func(move |model| {
                                         if undo {
-                                            if let Some(parent_id) = model.sub_objects[new_id].parent() {
-                                                let parent_children = &mut model.sub_objects[parent_id].children;
+                                            if let Some(parent_id) = model.submodels[new_id].parent() {
+                                                let parent_children = &mut model.submodels[parent_id].children;
                                                 parent_children.remove(parent_children.iter().position(|child_id| *child_id == new_id).unwrap());
                                             }
 
-                                            new_bufs = Some(model.buffer_objects.remove(new_id.0 as usize));
-                                            mat = Some(model.subobject_transform_matrix.remove(new_id.0 as usize));
-                                            new_subobj = Some(model.sub_objects.remove(new_id.0 as usize));
+                                            new_bufs = Some(model.buffer_meshes.remove(new_id.0 as usize));
+                                            mat = Some(model.submodel_transform_matrix.remove(new_id.0 as usize));
+                                            duped = Some(model.submodel_duplicated.remove(new_id.0 as usize));
+                                            new_smodel = Some(model.submodels.remove(new_id.0 as usize));
                                         } else {
-                                            model.buffer_objects.push(new_bufs.take().unwrap());
-                                            model.subobject_transform_matrix.push(mat.take().unwrap());
-                                            model.sub_objects.push(new_subobj.take().unwrap());
+                                            model.buffer_meshes.push(new_bufs.take().unwrap());
+                                            model.submodel_transform_matrix.push(mat.take().unwrap());
+                                            model.submodel_duplicated.push(duped.take().unwrap());
+                                            model.submodels.push(new_smodel.take().unwrap());
 
-                                            if let Some(parent_id) = model.sub_objects[new_id].parent() {
-                                                model.sub_objects[parent_id].children.push(new_id)
+                                            if let Some(parent_id) = model.submodels[new_id].parent() {
+                                                model.submodels[parent_id].children.push(new_id)
                                             }
                                         }
                                         undo = !undo;
@@ -1460,40 +1463,36 @@ impl PofToolsGui {
                                 let index = id.0 as usize;
                                 let deleted_id = id; // for clarity
 
-                                // the subobject we're going to select after having done the deletion
+                                // the submodel we're going to select after having done the deletion
                                 let mut reset_id = {
-                                    if let Some(parent_id) = self.model.sub_objects[deleted_id].parent {
+                                    if let Some(parent_id) = self.model.submodels[deleted_id].parent {
                                         // if it has a parent...
-                                        let list_idx = self.model.sub_objects[parent_id]
-                                            .children
-                                            .iter()
-                                            .position(|id| *id == deleted_id)
-                                            .unwrap();
+                                        let list_idx = self.model.submodels[parent_id].children.iter().position(|id| *id == deleted_id).unwrap();
                                         if list_idx > 0 {
                                             // use the next child
-                                            Some(self.model.sub_objects[parent_id].children[list_idx - 1])
+                                            Some(self.model.submodels[parent_id].children[list_idx - 1])
                                         } else {
                                             // else use the parent
                                             Some(parent_id)
                                         }
                                     } else {
-                                        // use the next top level object (if one exists)
+                                        // use the next top level model (if one exists)
                                         self.model
-                                            .sub_objects
+                                            .submodels
                                             .iter()
                                             .rev()
-                                            .filter(|subobj| subobj.parent.is_none() && subobj.obj_id < deleted_id)
-                                            .map(|subobj| subobj.obj_id)
+                                            .filter(|smodel| smodel.parent.is_none() && smodel.id < deleted_id)
+                                            .map(|smodel| smodel.id)
                                             .next()
                                     }
                                 };
 
                                 let mut id_map = HashMap::new();
-                                for subobj in &self.model.sub_objects {
-                                    if subobj.obj_id.0 > id.0 {
-                                        id_map.insert(subobj.obj_id, ObjectId(subobj.obj_id.0 - 1));
+                                for smodel in &self.model.submodels {
+                                    if smodel.id.0 > id.0 {
+                                        id_map.insert(smodel.id, SubmodelId(smodel.id.0 - 1));
                                     } else {
-                                        id_map.insert(subobj.obj_id, subobj.obj_id);
+                                        id_map.insert(smodel.id, smodel.id);
                                     }
                                 }
                                 reset_id = reset_id.map(|id| id_map[&id]);
@@ -1507,7 +1506,7 @@ impl PofToolsGui {
                                 let mut docking_bays = self.model.docking_bays.clone();
                                 let mut paths = self.model.paths.clone();
 
-                                self.model.header.num_subobjects -= 1;
+                                self.model.header.num_submodels -= 1;
                                 let mut removed_detail = false;
                                 // truncate if a detail level was deleted
                                 self.model.header.detail_levels.retain_mut(|id| {
@@ -1522,53 +1521,53 @@ impl PofToolsGui {
                                     }
                                 });
 
-                                // set any glow banks to the deleted object's parent, if it exists, otherwise delete
+                                // set any glow banks to the deleted model's parent, if it exists, otherwise delete
                                 self.model.pof_model.glow_banks.retain_mut(|bank| {
-                                    if bank.obj_parent == deleted_id {
-                                        if self.model.pof_model.sub_objects[bank.obj_parent].parent().is_some() {
-                                            bank.obj_parent = self.model.pof_model.sub_objects[deleted_id].parent.unwrap();
+                                    if bank.model_parent == deleted_id {
+                                        if self.model.pof_model.submodels[bank.model_parent].parent().is_some() {
+                                            bank.model_parent = self.model.pof_model.submodels[deleted_id].parent.unwrap();
                                             true
                                         } else {
                                             false
                                         }
                                     } else {
-                                        bank.obj_parent = id_map[&bank.obj_parent];
+                                        bank.model_parent = id_map[&bank.model_parent];
                                         true
                                     }
                                 });
 
                                 self.model.turrets.retain_mut(|turret| {
-                                    if turret.gun_obj == deleted_id {
-                                        turret.gun_obj = id_map[&turret.base_obj];
+                                    if turret.gun_model == deleted_id {
+                                        turret.gun_model = id_map[&turret.base_model];
                                     } else {
-                                        turret.gun_obj = id_map[&turret.gun_obj];
-                                        turret.base_obj = id_map[&turret.base_obj];
+                                        turret.gun_model = id_map[&turret.gun_model];
+                                        turret.base_model = id_map[&turret.base_model];
                                     }
-                                    turret.base_obj != deleted_id
+                                    turret.base_model != deleted_id
                                 });
 
                                 self.model.eye_points.iter_mut().for_each(|eye| {
-                                    if eye.attached_subobj == Some(deleted_id) {
-                                        eye.attached_subobj = None
-                                    } else if let Some(id) = eye.attached_subobj.as_mut() {
+                                    if eye.attached_submodel == Some(deleted_id) {
+                                        eye.attached_submodel = None
+                                    } else if let Some(id) = eye.attached_submodel.as_mut() {
                                         *id = id_map[id];
                                     }
                                 });
 
                                 self.model.pof_model.docking_bays.retain_mut(|bay| {
                                     let str = pof::properties_get_field(&bay.properties, "$parent_submodel");
-                                    str.is_none() || str.unwrap() != self.model.pof_model.sub_objects[deleted_id].name
+                                    str.is_none() || str.unwrap() != self.model.pof_model.submodels[deleted_id].name
                                 });
 
                                 self.model
                                     .pof_model
                                     .paths
-                                    .retain(|path| format!("${}", self.model.pof_model.sub_objects[deleted_id].name) != path.name);
+                                    .retain(|path| format!("${}", self.model.pof_model.submodels[deleted_id].name) != path.name);
 
-                                let mut buffer_obj = Some(self.model.buffer_objects.remove(index));
-                                let mut matrix = Some(self.model.subobject_transform_matrix.remove(index));
-                                let (x, child_list_idx) = self.model.delete_subobject_only(id);
-                                let mut subobj = Some(x);
+                                let mut buffer_mesh = Some(self.model.buffer_meshes.remove(index));
+                                let mut matrix = Some(self.model.submodel_transform_matrix.remove(index));
+                                let (x, child_list_idx) = self.model.delete_submodel_only(id);
+                                let mut submodel = Some(x);
 
                                 let mut undo = true;
                                 let mut first_time = true;
@@ -1579,15 +1578,15 @@ impl PofToolsGui {
                                     undo_func(move |model| {
                                         if !first_time {
                                             if undo {
-                                                model.insert_subobject_only(subobj.take().unwrap(), child_list_idx);
+                                                model.insert_submodel_only(submodel.take().unwrap(), child_list_idx);
 
-                                                model.subobject_transform_matrix.insert(index, matrix.take().unwrap());
-                                                model.buffer_objects.insert(index, buffer_obj.take().unwrap());
+                                                model.submodel_transform_matrix.insert(index, matrix.take().unwrap());
+                                                model.buffer_meshes.insert(index, buffer_mesh.take().unwrap());
                                             } else {
-                                                subobj = Some(model.delete_subobject_only(deleted_id).0);
+                                                submodel = Some(model.delete_submodel_only(deleted_id).0);
 
-                                                matrix = Some(model.subobject_transform_matrix.remove(index));
-                                                buffer_obj = Some(model.buffer_objects.remove(index));
+                                                matrix = Some(model.submodel_transform_matrix.remove(index));
+                                                buffer_mesh = Some(model.buffer_meshes.remove(index));
                                             }
 
                                             swap(&mut model.header, &mut header);
@@ -1605,8 +1604,8 @@ impl PofToolsGui {
                                 );
 
                                 selected_id = reset_id;
-                                self.ui_state.tree_view_selection = TreeValue::SubObjects(SubObjectTreeValue::subobj(reset_id));
-                                self.ui_state.last_selected_subobj = reset_id;
+                                self.ui_state.tree_view_selection = TreeValue::Submodels(SubmodelTreeValue::smodel(reset_id));
+                                self.ui_state.last_selected_smodel = reset_id;
 
                                 ui.close_menu();
                             }
@@ -1618,7 +1617,7 @@ impl PofToolsGui {
 
                 let mut text = LayoutJob::default();
                 text.append(
-                    "This will affect all child subobjects of this one, its turret firepoints if any and ",
+                    "This will affect all child submodels of this one, its turret firepoints if any and ",
                     0.0,
                     TextFormat {
                         font_id: TextStyle::Body.resolve(ui.style()),
@@ -1639,18 +1638,18 @@ impl PofToolsGui {
                     if let Some(id) = selected_id {
                         // even though the header version of this actually modifies the mesh, this just modifies the transform matrix
                         // ideally this would allow it to be undoable, but that's still really complicated...
-                        pub fn transform_subobj(model: &mut Model, id: ObjectId, matrix: &TMat4<f32>, transform_offset: bool) {
+                        pub fn transform_submodel(model: &mut Model, id: SubmodelId, matrix: &TMat4<f32>, transform_offset: bool) {
                             let no_trans_matrix = glm::set_row(matrix, 3, &glm::vec4(0.0, 0.0, 0.0, 1.0));
                             let rot_matrix = no_trans_matrix.normalize();
 
                             if !transform_offset {
-                                model.subobject_transform_matrix[id] *= matrix;
+                                model.submodel_transform_matrix[id] *= matrix;
                             } else {
-                                model.subobject_transform_matrix[id] *= no_trans_matrix;
+                                model.submodel_transform_matrix[id] *= no_trans_matrix;
                             }
 
                             for turret in &mut model.turrets {
-                                if id == turret.base_obj {
+                                if id == turret.base_model {
                                     for firepoint in &mut turret.fire_points {
                                         *firepoint = &no_trans_matrix * *firepoint;
                                     }
@@ -1658,20 +1657,20 @@ impl PofToolsGui {
                                 }
                             }
 
-                            if let Some((mut uvec, mut fvec)) = model.sub_objects[id].uvec_fvec() {
+                            if let Some((mut uvec, mut fvec)) = model.submodels[id].uvec_fvec() {
                                 uvec = &rot_matrix * uvec;
                                 fvec = &rot_matrix * fvec;
-                                pof::properties_update_field(&mut model.sub_objects[id].properties, "$uvec", &uvec.to_string());
-                                pof::properties_update_field(&mut model.sub_objects[id].properties, "$fvec", &fvec.to_string());
+                                pof::properties_update_field(&mut model.submodels[id].properties, "$uvec", &uvec.to_string());
+                                pof::properties_update_field(&mut model.submodels[id].properties, "$fvec", &fvec.to_string());
                             }
 
-                            let children: Vec<_> = model.sub_objects[id].children().copied().collect();
+                            let children: Vec<_> = model.submodels[id].children().copied().collect();
                             for child_id in children {
-                                transform_subobj(model, child_id, &no_trans_matrix, true)
+                                transform_submodel(model, child_id, &no_trans_matrix, true)
                             }
                         }
 
-                        transform_subobj(&mut self.model, id, &matrix, false);
+                        transform_submodel(&mut self.model, id, &matrix, false);
 
                         transform_window.open = false;
                     }
@@ -1686,29 +1685,29 @@ impl PofToolsGui {
                     if self
                         .model
                         .errors
-                        .contains(&Error::DuplicateSubobjectName(self.model.sub_objects[id].name.clone()))
-                        || self.model.errors.contains(&Error::UnnamedSubObject(id))
+                        .contains(&Error::DuplicateSubmodelName(self.model.submodels[id].name.clone()))
+                        || self.model.errors.contains(&Error::UnnamedSubmodel(id))
                     {
                         text = text.color(ERROR_RED);
                     }
                     ui.label(text);
-                    let old_name = self.model.sub_objects[id].name.clone();
+                    let old_name = self.model.submodels[id].name.clone();
 
                     if text_edit_single(
                         ui,
-                        "subobj name".to_string(),
+                        "submodel name".to_string(),
                         &mut self.model,
-                        path_func(move |model| &mut model.sub_objects[id].name),
+                        path_func(move |model| &mut model.submodels[id].name),
                         undo_history,
                     )
                     .changed()
                     {
-                        self.model.recheck_warnings(One(Warning::SubObjectNameTooLong(id)));
-                        self.model.recheck_errors(One(Error::UnnamedSubObject(id)));
-                        self.model.recheck_errors(One(Error::DuplicateSubobjectName(old_name)));
+                        self.model.recheck_warnings(One(Warning::SubmodelNameTooLong(id)));
+                        self.model.recheck_errors(One(Error::UnnamedSubmodel(id)));
+                        self.model.recheck_errors(One(Error::DuplicateSubmodelName(old_name)));
                         self.model
                             .pof_model
-                            .recheck_errors(One(Error::DuplicateSubobjectName(self.model.pof_model.sub_objects[id].name.clone())));
+                            .recheck_errors(One(Error::DuplicateSubmodelName(self.model.pof_model.submodels[id].name.clone())));
                         self.model.recalc_semantic_name_links();
                     }
                 } else {
@@ -1718,28 +1717,28 @@ impl PofToolsGui {
 
                 ui.add_space(5.0);
 
-                // Is Debris Object Checkbox ================================================================
+                // Is Debris Model Checkbox ================================================================
 
-                let num_debris = self.model.num_debris_objects();
+                let num_debris = self.model.num_debris_models();
                 let cannot_be_debris =
-                    num_debris >= pof::MAX_DEBRIS_OBJECTS || selected_id.is_some_and(|id| self.model.header.detail_levels.contains(&id));
+                    num_debris >= pof::MAX_DEBRIS_MODELS || selected_id.is_some_and(|id| self.model.header.detail_levels.contains(&id));
 
-                ui.add_enabled_ui(selected_id.is_some_and(|id| !cannot_be_debris || self.model.sub_objects[id].is_debris_model), |ui| {
+                ui.add_enabled_ui(selected_id.is_some_and(|id| !cannot_be_debris || self.model.submodels[id].is_debris_model), |ui| {
                     if selected_id.is_some_and(|id| {
-                        self.model.sub_objects[id].is_debris_model
-                            && (self.model.header.detail_levels.contains(&id) || num_debris > pof::MAX_DEBRIS_OBJECTS)
+                        self.model.submodels[id].is_debris_model
+                            && (self.model.header.detail_levels.contains(&id) || num_debris > pof::MAX_DEBRIS_MODELS)
                     }) {
                         UiState::set_widget_color(ui, ERROR_RED);
                     }
 
-                    let mut checkbox = ui.checkbox(is_debris_check, "Debris Subobject");
+                    let mut checkbox = ui.checkbox(is_debris_check, "Debris Submodel");
 
-                    if selected_id.is_some_and(|_| num_debris >= pof::MAX_DEBRIS_OBJECTS) {
-                        checkbox = checkbox.on_disabled_hover_text(format!("The maximum number of debris is {}", pof::MAX_DEBRIS_OBJECTS));
+                    if selected_id.is_some_and(|_| num_debris >= pof::MAX_DEBRIS_MODELS) {
+                        checkbox = checkbox.on_disabled_hover_text(format!("The maximum number of debris is {}", pof::MAX_DEBRIS_MODELS));
                     }
 
                     if selected_id.is_some_and(|id| self.model.header.detail_levels.contains(&id)) {
-                        checkbox = checkbox.on_disabled_hover_text(format!("A detail object cannot also be debris"));
+                        checkbox = checkbox.on_disabled_hover_text(format!("A detail model cannot also be debris"));
                     }
 
                     if checkbox.changed() {
@@ -1749,7 +1748,7 @@ impl PofToolsGui {
                             undo_history,
                             &mut self.model,
                             undo_func(move |model| {
-                                model.sub_objects[id].is_debris_model = !model.sub_objects[id].is_debris_model;
+                                model.submodels[id].is_debris_model = !model.submodels[id].is_debris_model;
                             }),
                         );
                     }
@@ -1777,7 +1776,7 @@ impl PofToolsGui {
                         format!("{} bounding box min", current_tree_selection),
                         ui,
                         false,
-                        selected_id.map(|id| path_func(move |model| &mut model.sub_objects[id].bbox.min)),
+                        selected_id.map(|id| path_func(move |model| &mut model.submodels[id].bbox.min)),
                         bbox_min_string
                     );
 
@@ -1793,7 +1792,7 @@ impl PofToolsGui {
                         format!("{} bounding box max", current_tree_selection),
                         ui,
                         false,
-                        selected_id.map(|id| path_func(move |model| &mut model.sub_objects[id].bbox.max)),
+                        selected_id.map(|id| path_func(move |model| &mut model.submodels[id].bbox.max)),
                         bbox_max_string
                     );
 
@@ -1806,12 +1805,12 @@ impl PofToolsGui {
                 let response = ui.add_enabled(selected_id.is_some(), egui::Button::new("Recalculate"));
                 if response.clicked() {
                     let id = selected_id.unwrap();
-                    let mut new_bbox = self.model.sub_objects[id].recalc_bbox();
+                    let mut new_bbox = self.model.submodels[id].recalc_bbox();
                     model_action(
                         undo_history,
                         &mut self.model,
                         undo_func(move |model| {
-                            swap(&mut model.sub_objects[id].bbox, &mut new_bbox);
+                            swap(&mut model.submodels[id].bbox, &mut new_bbox);
                         }),
                     );
                 }
@@ -1825,7 +1824,7 @@ impl PofToolsGui {
                 }
 
                 if let Some(id) = selected_id {
-                    let bbox = &self.model.sub_objects[id].bbox;
+                    let bbox = &self.model.submodels[id].bbox;
                     ui.horizontal_wrapped(|ui| {
                         ui.label(format!("Width:{NON_BREAK_SPACE}{:.1}", bbox.x_width()));
                         ui.label(format!("Height:{NON_BREAK_SPACE}{:.1}", bbox.y_height()));
@@ -1855,34 +1854,34 @@ impl PofToolsGui {
                 if let Some(id) = selected_id {
                     let only_offset = self.ui_state.move_only_offset;
                     let offset_move = parse_func(move |model: &Model, mut new_offset: Vec3d| {
-                        let mut diff = model.sub_objects[id].offset - new_offset;
-                        let mut new_radius = model.sub_objects[id].radius + diff.magnitude(); //this is an overestimate... maybe fix...
-                        let mut new_bbox = model.sub_objects[id].bbox.shift(diff);
+                        let mut diff = model.submodels[id].offset - new_offset;
+                        let mut new_radius = model.submodels[id].radius + diff.magnitude(); //this is an overestimate... maybe fix...
+                        let mut new_bbox = model.submodels[id].bbox.shift(diff);
                         if only_offset {
                             undo_func(move |model| {
-                                let subobj = &mut model.sub_objects[id];
-                                swap(&mut subobj.offset, &mut new_offset);
-                                swap(&mut subobj.radius, &mut new_radius);
-                                swap(&mut subobj.bbox, &mut new_bbox);
-                                let children: Vec<_> = subobj.children().copied().collect();
+                                let smodel = &mut model.submodels[id];
+                                swap(&mut smodel.offset, &mut new_offset);
+                                swap(&mut smodel.radius, &mut new_radius);
+                                swap(&mut smodel.bbox, &mut new_bbox);
+                                let children: Vec<_> = smodel.children().copied().collect();
                                 for id in children {
-                                    model.sub_objects[id].offset += diff;
+                                    model.submodels[id].offset += diff;
                                 }
-                                model.subobject_transform_matrix[id].append_translation_mut(&diff.into());
+                                model.submodel_transform_matrix[id].append_translation_mut(&diff.into());
 
                                 diff = -diff;
-                                info!("Modifying: Subobject - {:?} - offset", id);
+                                info!("Modifying: Submodel - {:?} - offset", id);
                             })
                         } else {
                             undo_func(move |model| {
-                                swap(&mut model.sub_objects[id].offset, &mut new_offset);
-                                info!("Modifying: Subobject - {:?} - offset", id);
+                                swap(&mut model.submodels[id].offset, &mut new_offset);
+                                info!("Modifying: Submodel - {:?} - offset", id);
                             })
                         }
                     });
 
                     let response = UiState::model_value_edit_custom(
-                        "subobj offset",
+                        "smodel offset",
                         &mut self.ui_state.viewport_3d_dirty,
                         ui,
                         false,
@@ -1904,26 +1903,26 @@ impl PofToolsGui {
                 let response = ui.add_enabled(selected_id.is_some(), egui::Button::new("Recalculate"));
                 if response.clicked() {
                     let id = selected_id.unwrap();
-                    let mut new_offset = self.model.recalc_subobj_offset(id);
-                    let mut diff = self.model.sub_objects[id].offset - new_offset;
-                    let mut new_radius = self.model.sub_objects[id].radius + diff.magnitude(); //this is an overestimate... maybe fix...
-                    let mut new_bbox = self.model.sub_objects[id].bbox.shift(diff);
+                    let mut new_offset = self.model.recalc_submodel_offset(id);
+                    let mut diff = self.model.submodels[id].offset - new_offset;
+                    let mut new_radius = self.model.submodels[id].radius + diff.magnitude(); //this is an overestimate... maybe fix...
+                    let mut new_bbox = self.model.submodels[id].bbox.shift(diff);
                     model_action(
                         undo_history,
                         &mut self.model,
                         undo_func(move |model| {
-                            let subobj = &mut model.sub_objects[id];
-                            swap(&mut subobj.offset, &mut new_offset);
-                            swap(&mut subobj.radius, &mut new_radius);
-                            swap(&mut subobj.bbox, &mut new_bbox);
-                            let children: Vec<_> = subobj.children().copied().collect();
+                            let smodel = &mut model.submodels[id];
+                            swap(&mut smodel.offset, &mut new_offset);
+                            swap(&mut smodel.radius, &mut new_radius);
+                            swap(&mut smodel.bbox, &mut new_bbox);
+                            let children: Vec<_> = smodel.children().copied().collect();
                             for id in children {
-                                model.sub_objects[id].offset += diff;
+                                model.submodels[id].offset += diff;
                             }
-                            model.subobject_transform_matrix[id].append_translation_mut(&diff.into());
+                            model.submodel_transform_matrix[id].append_translation_mut(&diff.into());
 
                             diff = -diff;
-                            info!("Recalculating: Subobject - {:?} - offset", id);
+                            info!("Recalculating: Submodel - {:?} - offset", id);
                         }),
                     );
                     self.ui_state.viewport_3d_dirty = true;
@@ -1934,7 +1933,7 @@ impl PofToolsGui {
                 let response = ui
                     .add_enabled(selected_id.is_some(), egui::Checkbox::new(&mut self.ui_state.move_only_offset, "Modify Offset Only"))
                     .on_hover_text(
-                        "Changes will affect only the offset/center of this subobject, all other geometry remains in place.\nThe radius will be recalculated.",
+                        "Changes will affect only the offset/center of this submodel, all other geometry remains in place.\nThe radius will be recalculated.",
                     );
                 display_origin |= response.hovered() || response.has_focus();
 
@@ -1957,7 +1956,7 @@ impl PofToolsGui {
                     format!("{} radius", current_tree_selection),
                     ui,
                     self.model.warnings.contains(&Warning::RadiusTooSmall(selected_id)),
-                    selected_id.map(|id| path_func(move |model| &mut model.sub_objects[id].radius)),
+                    selected_id.map(|id| path_func(move |model| &mut model.submodels[id].radius)),
                     radius_string
                 );
                 display_radius |= response.hovered() || response.has_focus();
@@ -1969,13 +1968,13 @@ impl PofToolsGui {
                 let response = ui.add_enabled(selected_id.is_some(), egui::Button::new("Recalculate"));
                 if response.clicked() {
                     let id = selected_id.unwrap();
-                    let mut new_radius = self.model.sub_objects[id].recalc_radius();
+                    let mut new_radius = self.model.submodels[id].recalc_radius();
 
                     model_action(
                         undo_history,
                         &mut self.model,
                         undo_func(move |model| {
-                            swap(&mut model.sub_objects[id].radius, &mut new_radius);
+                            swap(&mut model.submodels[id].radius, &mut new_radius);
                         }),
                     );
                 }
@@ -1985,34 +1984,32 @@ impl PofToolsGui {
 
                 ui.separator();
 
-                // Parent subobject combo box ================================================================
+                // Parent submodel combo box ================================================================
 
                 // first index is none
-                let mut subobj_names_list = vec![format!("None")];
+                let mut submodel_names_list = vec![format!("None")];
                 let mut combo_idx = 0;
                 // add the current parent if it exists as the second entry
-                if let Some(parent_id) = selected_id.and_then(|id| self.model.sub_objects[id].parent()) {
-                    subobj_names_list.push(self.model.sub_objects[parent_id].name.clone());
+                if let Some(parent_id) = selected_id.and_then(|id| self.model.submodels[id].parent()) {
+                    submodel_names_list.push(self.model.submodels[parent_id].name.clone());
                     combo_idx = 1;
                 }
 
-                // fill the remainder with the rest of the subobjects which are NOT children of this one
+                // fill the remainder with the rest of the submodels which are NOT children of this one
                 if let Some(id) = selected_id {
-                    subobj_names_list.extend(
+                    submodel_names_list.extend(
                         self.model
-                            .sub_objects
+                            .submodels
                             .iter()
-                            .filter(|subobj| {
-                                self.model.sub_objects[id].parent() != Some(subobj.obj_id) && !self.model.is_obj_id_ancestor(subobj.obj_id, id)
-                            })
-                            .map(|subobj| subobj.name.clone()),
+                            .filter(|smodel| self.model.submodels[id].parent() != Some(smodel.id) && !self.model.is_model_id_ancestor(smodel.id, id))
+                            .map(|smodel| smodel.name.clone()),
                     );
                 }
 
-                if let Some(new_parent) = UiState::subobject_combo_box(ui, &subobj_names_list, &mut combo_idx, selected_id, "Parent", None, None) {
+                if let Some(new_parent) = UiState::submodel_combo_box(ui, &submodel_names_list, &mut combo_idx, selected_id, "Parent", None, None) {
                     let id = selected_id.unwrap();
                     let mut new_parent = if new_parent != 0 {
-                        self.model.get_obj_id_by_name(&subobj_names_list[new_parent])
+                        self.model.get_model_id_by_name(&submodel_names_list[new_parent])
                     } else {
                         None
                     };
@@ -2021,7 +2018,7 @@ impl PofToolsGui {
                         undo_history,
                         &mut self.model,
                         undo_func(move |model| {
-                            let old_parent = model.sub_objects[id].parent;
+                            let old_parent = model.submodels[id].parent;
                             model.make_orphan(id);
                             if let Some(parent_id) = new_parent {
                                 new_parent = old_parent; // swap in the old value
@@ -2035,7 +2032,7 @@ impl PofToolsGui {
 
                 ui.label("Properties:");
                 if let Some(id) = selected_id {
-                    if self.model.sub_objects[id].uvec_fvec().is_some() {
+                    if self.model.submodels[id].uvec_fvec().is_some() {
                         self.ui_state.display_uvec_fvec = true;
                     }
 
@@ -2044,11 +2041,11 @@ impl PofToolsGui {
                         format!("{} properties", current_tree_selection),
                         2,
                         &mut self.model,
-                        path_func(move |model| &mut model.sub_objects[id].properties),
+                        path_func(move |model| &mut model.submodels[id].properties),
                         undo_history,
                     );
                     if widget_response.changed() {
-                        self.model.recheck_warnings(One(Warning::SubObjectPropertiesTooLong(id)));
+                        self.model.recheck_warnings(One(Warning::SubmodelPropertiesTooLong(id)));
                         self.ui_state.viewport_3d_dirty = true; // There may be changes to the uvec/fvec
                     };
                 } else {
@@ -2075,12 +2072,12 @@ impl PofToolsGui {
                                 undo_history,
                                 &mut self.model,
                                 undo_func(move |model: &mut Model| {
-                                    let obj = &mut model.sub_objects[id];
-                                    swap(&mut obj.rotation_axis, &mut new_axis);
-                                    if obj.rotation_axis == SubsysRotationAxis::None {
-                                        obj.rotation_type = SubsysRotationType::None
-                                    } else if obj.rotation_type == SubsysRotationType::None {
-                                        obj.rotation_type = SubsysRotationType::Regular
+                                    let smodel = &mut model.submodels[id];
+                                    swap(&mut smodel.rotation_axis, &mut new_axis);
+                                    if smodel.rotation_axis == SubsysRotationAxis::None {
+                                        smodel.rotation_type = SubsysRotationType::None
+                                    } else if smodel.rotation_type == SubsysRotationType::None {
+                                        smodel.rotation_type = SubsysRotationType::Regular
                                     }
                                 }),
                             );
@@ -2088,7 +2085,7 @@ impl PofToolsGui {
                     });
 
                     ui.vertical(|ui| {
-                        if selected_id.is_some_and(|id| self.model.warnings.contains(&Warning::SubObjectTranslationInvalidVersion(id))) {
+                        if selected_id.is_some_and(|id| self.model.warnings.contains(&Warning::SubmodelTranslationInvalidVersion(id))) {
                             UiState::set_widget_color(ui, WARNING_YELLOW);
                             ui.label("Translation Axis:");
                             UiState::reset_widget_color(ui);
@@ -2120,12 +2117,12 @@ impl PofToolsGui {
                                 undo_history,
                                 &mut self.model,
                                 undo_func(move |model: &mut Model| {
-                                    let obj = &mut model.sub_objects[id];
-                                    swap(&mut obj.translation_axis, &mut new_axis);
-                                    if obj.translation_axis == SubsysTranslationAxis::None {
-                                        obj.translation_type = SubsysTranslationType::None
-                                    } else if obj.translation_type == SubsysTranslationType::None {
-                                        obj.translation_type = SubsysTranslationType::Regular
+                                    let smodel = &mut model.submodels[id];
+                                    swap(&mut smodel.translation_axis, &mut new_axis);
+                                    if smodel.translation_axis == SubsysTranslationAxis::None {
+                                        smodel.translation_type = SubsysTranslationType::None
+                                    } else if smodel.translation_type == SubsysTranslationType::None {
+                                        smodel.translation_type = SubsysTranslationType::Regular
                                     }
                                 }),
                             );
@@ -2137,7 +2134,7 @@ impl PofToolsGui {
                 // Theoretically should be a decent metric for BSP tree efficiency; lower = better
                 //
                 // if ui.button("avg depth").clicked() {
-                //     let node = &self.model.sub_objects[selected_id.unwrap()].bsp_data.collision_tree;
+                //     let node = &self.model.submodels[selected_id.unwrap()].bsp_data.collision_tree;
                 //     let bbox_vol = match node {
                 //         pof::BspNode::Split { bbox, .. } | pof::BspNode::Leaf { bbox, .. } => bbox.volume(),
                 //     };
@@ -2153,22 +2150,22 @@ impl PofToolsGui {
                 // Semantic name links ================================================================
 
                 if let Some(id) = selected_id {
-                    let subobj = &self.model.sub_objects[id];
-                    if !subobj.name_links.is_empty() {
+                    let smodel = &self.model.submodels[id];
+                    if !smodel.name_links.is_empty() {
                         ui.separator();
 
                         let mut has_live_debris = false;
                         let mut has_detail_level = false;
-                        for link in &subobj.name_links {
+                        for link in &smodel.name_links {
                             match *link {
                                 pof::NameLink::DestroyedVersion(destroyed_id) => {
                                     ui.horizontal_wrapped(|ui| {
                                         ui.label(RichText::new(format!("Has a destroyed version:")).weak().color(Color32::LIGHT_RED));
                                         if ui
-                                            .button(RichText::new(&self.model.sub_objects[destroyed_id].name).weak().color(Color32::LIGHT_RED))
+                                            .button(RichText::new(&self.model.submodels[destroyed_id].name).weak().color(Color32::LIGHT_RED))
                                             .clicked()
                                         {
-                                            select_new_tree_val!(TreeValue::SubObjects(SubObjectTreeValue::SubObject(destroyed_id)));
+                                            select_new_tree_val!(TreeValue::Submodels(SubmodelTreeValue::Submodel(destroyed_id)));
                                         }
                                     });
                                 }
@@ -2176,34 +2173,34 @@ impl PofToolsGui {
                                     ui.horizontal_wrapped(|ui| {
                                         ui.label(RichText::new(format!("Is the destroyed version of: ")).weak().color(Color32::LIGHT_RED));
                                         if ui
-                                            .button(RichText::new(&self.model.sub_objects[intact_id].name).weak().color(Color32::LIGHT_RED))
+                                            .button(RichText::new(&self.model.submodels[intact_id].name).weak().color(Color32::LIGHT_RED))
                                             .clicked()
                                         {
-                                            select_new_tree_val!(TreeValue::SubObjects(SubObjectTreeValue::SubObject(intact_id)));
+                                            select_new_tree_val!(TreeValue::Submodels(SubmodelTreeValue::Submodel(intact_id)));
                                         }
                                     });
                                 }
                                 pof::NameLink::LiveDebris(_) => has_live_debris = true,
                                 pof::NameLink::LiveDebrisOf(debris_parent_id) => {
                                     ui.horizontal_wrapped(|ui| {
-                                        ui.label(RichText::new(format!("Is a debris object of: ")).weak().color(LIGHT_ORANGE));
+                                        ui.label(RichText::new(format!("Is a debris model of: ")).weak().color(LIGHT_ORANGE));
                                         if ui
-                                            .button(RichText::new(&self.model.sub_objects[debris_parent_id].name).weak().color(LIGHT_ORANGE))
+                                            .button(RichText::new(&self.model.submodels[debris_parent_id].name).weak().color(LIGHT_ORANGE))
                                             .clicked()
                                         {
-                                            select_new_tree_val!(TreeValue::SubObjects(SubObjectTreeValue::SubObject(debris_parent_id)));
+                                            select_new_tree_val!(TreeValue::Submodels(SubmodelTreeValue::Submodel(debris_parent_id)));
                                         }
                                     });
                                 }
                                 pof::NameLink::DetailLevel(..) => has_detail_level = true,
                                 pof::NameLink::DetailLevelOf(detail_parent_id, _) => {
                                     ui.horizontal_wrapped(|ui| {
-                                        ui.label(RichText::new(format!("Is a detail object of: ")).weak().color(LIGHT_BLUE));
+                                        ui.label(RichText::new(format!("Is a detail model of: ")).weak().color(LIGHT_BLUE));
                                         if ui
-                                            .button(RichText::new(&self.model.sub_objects[detail_parent_id].name).weak().color(LIGHT_BLUE))
+                                            .button(RichText::new(&self.model.submodels[detail_parent_id].name).weak().color(LIGHT_BLUE))
                                             .clicked()
                                         {
-                                            select_new_tree_val!(TreeValue::SubObjects(SubObjectTreeValue::SubObject(detail_parent_id)));
+                                            select_new_tree_val!(TreeValue::Submodels(SubmodelTreeValue::Submodel(detail_parent_id)));
                                         }
                                     });
                                 }
@@ -2211,28 +2208,28 @@ impl PofToolsGui {
                         }
 
                         if has_live_debris {
-                            ui.label(RichText::new(format!("Has sub-debris objects:")).weak().color(LIGHT_ORANGE));
-                            for link in &subobj.name_links {
+                            ui.label(RichText::new(format!("Has sub-debris models:")).weak().color(LIGHT_ORANGE));
+                            for link in &smodel.name_links {
                                 if let pof::NameLink::LiveDebris(id) = *link {
                                     if ui
-                                        .button(RichText::new(&self.model.sub_objects[id].name).weak().color(LIGHT_ORANGE))
+                                        .button(RichText::new(&self.model.submodels[id].name).weak().color(LIGHT_ORANGE))
                                         .clicked()
                                     {
-                                        select_new_tree_val!(TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)));
+                                        select_new_tree_val!(TreeValue::Submodels(SubmodelTreeValue::Submodel(id)));
                                     }
                                 }
                             }
                         }
 
                         if has_detail_level {
-                            ui.label(RichText::new(format!("Has detail level objects:")).weak().color(LIGHT_BLUE));
-                            for link in &subobj.name_links {
+                            ui.label(RichText::new(format!("Has detail level models:")).weak().color(LIGHT_BLUE));
+                            for link in &smodel.name_links {
                                 if let pof::NameLink::DetailLevel(id, _) = *link {
                                     if ui
-                                        .button(RichText::new(&self.model.sub_objects[id].name).weak().color(LIGHT_BLUE))
+                                        .button(RichText::new(&self.model.submodels[id].name).weak().color(LIGHT_BLUE))
                                         .clicked()
                                     {
-                                        select_new_tree_val!(TreeValue::SubObjects(SubObjectTreeValue::SubObject(id)));
+                                        select_new_tree_val!(TreeValue::Submodels(SubmodelTreeValue::Submodel(id)));
                                     }
                                 }
                             }
@@ -2245,12 +2242,12 @@ impl PofToolsGui {
                 ui.separator();
 
                 if let Some(id) = selected_id {
-                    ui.label(RichText::new(format!("Id: {:?}", self.model.sub_objects[id].obj_id)).weak());
-                    let mut vert_string = RichText::new(format!("Vertices: {}", self.model.sub_objects[id].bsp_data.verts.len())).weak();
+                    ui.label(RichText::new(format!("Id: {:?}", self.model.submodels[id].id)).weak());
+                    let mut vert_string = RichText::new(format!("Vertices: {}", self.model.submodels[id].bsp_data.verts.len())).weak();
                     if self.model.errors.contains(&Error::TooManyVerts(id)) {
                         vert_string = vert_string.color(ERROR_RED);
                     }
-                    let mut norm_string = RichText::new(format!("Normals: {}", self.model.sub_objects[id].bsp_data.norms.len())).weak();
+                    let mut norm_string = RichText::new(format!("Normals: {}", self.model.submodels[id].bsp_data.norms.len())).weak();
                     if self.model.errors.contains(&Error::TooManyNorms(id)) {
                         norm_string = norm_string.color(ERROR_RED);
                     }
@@ -2635,12 +2632,12 @@ impl PofToolsGui {
                     }
                 });
 
-                let mut subobj_names_list = vec!["None".to_string()];
+                let mut submodel_names_list = vec!["None".to_string()];
 
                 let mut warning_idx = None;
                 if bay_num.is_some_and(|idx| self.model.warnings.contains(&Warning::InvalidDockParentSubmodel(idx))) {
-                    // this bay has an invalid parent object, so add whatever its name is to the list
-                    subobj_names_list.push(
+                    // this bay has an invalid parent model, so add whatever its name is to the list
+                    submodel_names_list.push(
                         pof::properties_get_field(&self.model.docking_bays[bay_num.unwrap()].properties, "$parent_submodel")
                             .unwrap()
                             .to_string(),
@@ -2648,11 +2645,11 @@ impl PofToolsGui {
                     warning_idx = Some(1);
                 }
 
-                subobj_names_list.extend(self.model.get_subobj_names());
+                submodel_names_list.extend(self.model.get_smodel_names());
 
                 let mut parent_id = if let Some(bay) = bay_num {
-                    self.model.docking_bays[bay].get_parent_obj().map_or(0, |parent_name| {
-                        subobj_names_list
+                    self.model.docking_bays[bay].get_parent_smodel().map_or(0, |parent_name| {
+                        submodel_names_list
                             .iter()
                             .position(|name| name.to_lowercase() == parent_name.to_lowercase())
                             .unwrap_or(0)
@@ -2661,11 +2658,11 @@ impl PofToolsGui {
                     0 // doesnt matter
                 };
 
-                if let Some(new_subobj) =
-                    UiState::subobject_combo_box(ui, &subobj_names_list, &mut parent_id, bay_num, "Parent Object", None, warning_idx)
+                if let Some(new_smodel) =
+                    UiState::submodel_combo_box(ui, &submodel_names_list, &mut parent_id, bay_num, "Submodel", None, warning_idx)
                 {
                     let bay_num = bay_num.unwrap();
-                    let mut new_name = subobj_names_list[new_subobj].clone();
+                    let mut new_name = submodel_names_list[new_smodel].clone();
                     let mut old_name = pof::properties_get_field(&self.model.docking_bays[bay_num].properties, "$parent_submodel")
                         .unwrap_or_default()
                         .to_owned();
@@ -2847,7 +2844,7 @@ impl PofToolsGui {
                 lod_string,
                 glow_type_string,
                 glow_texture_string,
-                attached_subobj_idx,
+                attached_submodel_idx,
                 position_string,
                 normal_string,
                 radius_string,
@@ -2861,8 +2858,8 @@ impl PofToolsGui {
                     _ => (None, None),
                 };
 
-                // no subobjects = no glow banks allowed
-                let glow_banks_opt = (!self.model.sub_objects.is_empty()).then(|| &self.model.glow_banks);
+                // no submodels = no glow banks allowed
+                let glow_banks_opt = (!self.model.submodels.is_empty()).then(|| &self.model.glow_banks);
                 let bank_idx_response = UiState::list_manipulator_widget(ui, bank_num, glow_banks_opt, "Bank");
 
                 ui.add_space(10.0);
@@ -2887,17 +2884,18 @@ impl PofToolsGui {
                     ui.add_enabled(false, egui::TextEdit::singleline(&mut blank_string).desired_rows(1));
                 }
 
-                let subobj_names_list = self.model.get_subobj_names();
+                let submodel_names_list = self.model.get_smodel_names();
 
-                if let Some(new_subobj) = UiState::subobject_combo_box(ui, &subobj_names_list, attached_subobj_idx, bank_num, "SubObject", None, None)
+                if let Some(new_submodel) =
+                    UiState::submodel_combo_box(ui, &submodel_names_list, attached_submodel_idx, bank_num, "Submodel", None, None)
                 {
                     let num = bank_num.unwrap();
-                    let mut new_id = ObjectId(new_subobj as u32);
+                    let mut new_id = SubmodelId(new_submodel as u32);
                     model_action(
                         undo_history,
                         &mut self.model,
                         undo_func(move |model| {
-                            swap(&mut model.glow_banks[num].obj_parent, &mut new_id);
+                            swap(&mut model.glow_banks[num].model_parent, &mut new_id);
                         }),
                     );
                 }
@@ -3163,66 +3161,66 @@ impl PofToolsGui {
                     _ => (None, None),
                 };
 
-                // no subobjects = no turrets allowed
-                let turrets_opt = (!self.model.sub_objects.is_empty()).then(|| &self.model.turrets);
+                // no submodels = no turrets allowed
+                let turrets_opt = (!self.model.submodels.is_empty()).then(|| &self.model.turrets);
                 let turret_idx_response = UiState::list_manipulator_widget(ui, turret_num, turrets_opt, "Turret");
 
                 ui.add_space(10.0);
-                let subobj_names_list = self.model.get_subobj_names();
+                let submodel_names_list = self.model.get_smodel_names();
 
-                if let Some(new_subobj) = UiState::subobject_combo_box(ui, &subobj_names_list, base_idx, turret_num, "Base object", None, None) {
-                    let mut new_val = ObjectId(new_subobj as u32);
+                if let Some(new_submodel) = UiState::submodel_combo_box(ui, &submodel_names_list, base_idx, turret_num, "Base model", None, None) {
+                    let mut new_val = SubmodelId(new_submodel as u32);
                     let turret_num = turret_num.unwrap(); // the unwrap is ok here, if it were none, the combo box would be un-interactable
 
                     model_action(
                         undo_history,
                         &mut self.model,
                         undo_func(move |model: &mut Model| {
-                            let val = &mut model.turrets[turret_num].base_obj;
+                            let val = &mut model.turrets[turret_num].base_model;
                             swap(&mut new_val, val);
                         }),
                     );
                 }
 
-                // turret gun subobject combo box is a bit trickier since we only want to show valid subobjects (and the currently used one,
+                // turret gun submodel combo box is a bit trickier since we only want to show valid submodels (and the currently used one,
                 // which may be invalid)
 
-                let mut gun_subobj_ids_list = vec![];
-                let mut gun_subobj_idx = 0;
+                let mut gun_smodel_ids_list = vec![];
+                let mut gun_smodel_idx = 0;
                 let mut error_idx = None;
                 // assemble the list of ids, and get the index of the currently being used one
                 if let Some(num) = turret_num {
                     let (list, idx) = self
                         .model
-                        .get_valid_gun_subobjects_for_turret(self.model.turrets[num].gun_obj, self.model.turrets[num].base_obj);
-                    gun_subobj_ids_list = list;
-                    gun_subobj_idx = idx;
-                    if self.model.errors.contains(&Error::InvalidTurretGunSubobject(num)) {
-                        for (i, &id) in gun_subobj_ids_list.iter().enumerate() {
-                            if id == self.model.turrets[num].gun_obj {
+                        .get_valid_gun_submodels_for_turret(self.model.turrets[num].gun_model, self.model.turrets[num].base_model);
+                    gun_smodel_ids_list = list;
+                    gun_smodel_idx = idx;
+                    if self.model.errors.contains(&Error::InvalidTurretGunSubmodel(num)) {
+                        for (i, &id) in gun_smodel_ids_list.iter().enumerate() {
+                            if id == self.model.turrets[num].gun_model {
                                 error_idx = Some(i);
                             }
                         }
                     }
                 }
                 // assemble the string names list from the id list
-                let gun_subobj_names_list = gun_subobj_ids_list
+                let gun_submodel_names_list = gun_smodel_ids_list
                     .iter()
-                    .map(|id| self.model.sub_objects[*id].name.clone())
+                    .map(|id| self.model.submodels[*id].name.clone())
                     .collect::<Vec<_>>();
 
                 // then make the combo box, giving it the list of names and the index
                 if let Some(new_idx) =
-                    UiState::subobject_combo_box(ui, &gun_subobj_names_list, &mut gun_subobj_idx, turret_num, "Gun object", error_idx, None)
+                    UiState::submodel_combo_box(ui, &gun_submodel_names_list, &mut gun_smodel_idx, turret_num, "Gun model", error_idx, None)
                 {
-                    let mut new_val = gun_subobj_ids_list[new_idx];
+                    let mut new_val = gun_smodel_ids_list[new_idx];
                     let turret_num = turret_num.unwrap(); // the unwrap is ok here, if it were none, the combo box would be un-interactable
 
                     model_action(
                         undo_history,
                         &mut self.model,
                         undo_func(move |model: &mut Model| {
-                            let val = &mut model.turrets[turret_num].gun_obj;
+                            let val = &mut model.turrets[turret_num].gun_model;
                             swap(&mut new_val, val);
                         }),
                     );
@@ -3423,7 +3421,7 @@ impl PofToolsGui {
                     select_new_tree_val!(TreeValue::Paths(PathTreeValue::path_point(path_num.unwrap(), new_idx)));
                 }
 
-                // Auto-Gen Paths: generates approach paths for all turrets, subsystem subobjects,
+                // Auto-Gen Paths: generates approach paths for all turrets, subsystem submodels,
                 // subsystem special points, and docking bays that don't already have paths.
                 // Ported from PCS2
                 ui.add_space(10.0);
@@ -3521,7 +3519,7 @@ impl PofToolsGui {
                 ui.label("Offset:");
                 model_value_widget!(format!("{} offset", current_tree_selection), ui, false, offset, offset_string);
             }
-            PropertiesPanel::EyePoint { position_string, normal_string, attached_subobj_idx } => {
+            PropertiesPanel::EyePoint { position_string, normal_string, attached_submodel_idx } => {
                 ui.heading("Eye Point");
                 ui.separator();
 
@@ -3530,24 +3528,24 @@ impl PofToolsGui {
                     _ => None,
                 };
 
-                // no subobjects = no eye points allowed
-                let eye_points_opt = (!self.model.sub_objects.is_empty()).then(|| &self.model.eye_points);
+                // no submodels = no eye points allowed
+                let eye_points_opt = (!self.model.submodels.is_empty()).then(|| &self.model.eye_points);
                 let eye_idx_response = UiState::list_manipulator_widget(ui, eye_num, eye_points_opt, "Eye Point");
 
                 ui.add_space(10.0);
 
                 ui.add_enabled_ui(eye_num.is_some(), |ui| {
                     if let Some(num) = eye_num {
-                        let mut name_list = self.model.get_subobj_names();
+                        let mut name_list = self.model.get_smodel_names();
                         name_list.push("None".to_string());
 
                         let changed = egui::ComboBox::from_label("Attached submodel")
-                            .show_index(ui, attached_subobj_idx, name_list.len(), |i| name_list[i].to_owned())
+                            .show_index(ui, attached_submodel_idx, name_list.len(), |i| name_list[i].to_owned())
                             .changed();
 
                         if changed {
-                            let mut new_val = if *attached_subobj_idx < self.model.sub_objects.len() {
-                                Some(ObjectId(*attached_subobj_idx as u32))
+                            let mut new_val = if *attached_submodel_idx < self.model.submodels.len() {
+                                Some(SubmodelId(*attached_submodel_idx as u32))
                             } else {
                                 None
                             };
@@ -3556,13 +3554,13 @@ impl PofToolsGui {
                                 undo_history,
                                 &mut self.model,
                                 undo_func(move |model: &mut Model| {
-                                    let val = &mut model.eye_points[num].attached_subobj;
+                                    let val = &mut model.eye_points[num].attached_submodel;
                                     swap(&mut new_val, val);
                                 }),
                             );
                         }
                     } else {
-                        egui::ComboBox::from_label("Attached submodel").show_index(ui, attached_subobj_idx, 1, |_| format!(""));
+                        egui::ComboBox::from_label("Attached submodel").show_index(ui, attached_submodel_idx, 1, |_| format!(""));
                     }
                 });
 


### PR DESCRIPTION
Two main reasons for this: firstly the name is more accurate, theses are subordinate to the model, not an object, which is a distinct and different thing to FSO and secondly because it matches more recent FSO documentation and features which also use "submodel".

Also a few unrelated tweaks to moron detection.